### PR TITLE
Fixed Back Button Page going to either `FeedView` or `MapView`, instead of only to the feed

### DIFF
--- a/Spawn-App-iOS-SwiftUI/Views/Enums/BackButtonSourcePageType.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/Enums/BackButtonSourcePageType.swift
@@ -1,0 +1,10 @@
+//
+//  BackButtonSourcePageType.swift
+//  Spawn-App-iOS-SwiftUI
+//
+//  Created by Daniel Agapov on 2025-01-01.
+//
+
+enum BackButtonSourcePageType {
+	case feed, map
+}

--- a/Spawn-App-iOS-SwiftUI/Views/FriendsView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FriendsView.swift
@@ -9,10 +9,13 @@ import SwiftUI
 
 struct FriendsView: View {
     let user: User
+	let source: BackButtonSourcePageType
+
     @State private var selectedTab: FriendTagToggle = .tags // TODO DANIEL: change back to friends later by default
     
-    init(user: User) {
+	init(user: User, source: BackButtonSourcePageType) {
         self.user = user
+		self.source = source
     }
     
     var body: some View {
@@ -35,7 +38,7 @@ struct FriendsView: View {
 private extension FriendsView {
     var header: some View {
         HStack {
-            BackButton()
+			BackButton(source: source)
             Spacer()
             Picker("", selection: $selectedTab) {
                 Text("friends")
@@ -66,5 +69,5 @@ private extension FriendsView {
 	@Previewable @StateObject var observableUser: ObservableUser = ObservableUser(
 		user: .danielLee
 	)
-	FriendsView(user: observableUser.user)
+	FriendsView(user: observableUser.user, source: .feed)
 }

--- a/Spawn-App-iOS-SwiftUI/Views/MapView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/MapView.swift
@@ -75,11 +75,11 @@ struct MapView: View {
 				.padding(.top, 20)
 				Spacer()
 				HStack(spacing: 35) {
-					BottomNavButtonView(buttonType: .feed)
+					BottomNavButtonView(buttonType: .feed, source: .map)
 					Spacer()
-					BottomNavButtonView(buttonType: .plus)
+					BottomNavButtonView(buttonType: .plus, source: .map)
 					Spacer()
-					BottomNavButtonView(buttonType: .friends)
+					BottomNavButtonView(buttonType: .friends, source: .map)
 					// TODO: make work after designs are finalized
 				}
 				.padding(32)

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/FeedSubViews/BottomNavButtonView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/FeedSubViews/BottomNavButtonView.swift
@@ -12,8 +12,9 @@ struct BottomNavButtonView: View {
     var buttonType: BottomNavButtonType
     var imageName: String
     var imageSize: CGFloat = 25
-    
-    init(buttonType: BottomNavButtonType) {
+	let source: BackButtonSourcePageType
+
+	init(buttonType: BottomNavButtonType, source: BackButtonSourcePageType = .feed) {
         self.buttonType = buttonType
         switch(buttonType) {
             case .map:
@@ -26,6 +27,7 @@ struct BottomNavButtonView: View {
                 self.imageName = "list.bullet"
                 self.imageSize = 12
         }
+		self.source = source
     }
     
     var body: some View {
@@ -74,7 +76,7 @@ struct BottomNavButtonView: View {
                     .modifier(CircularButtonStyling(width: 25, height: 20, frameSize: 45, source: "map"))
                     .overlay(
                         NavigationLink(destination: {
-                            FriendsView(user: user.user)
+							FriendsView(user: user.user, source: source)
                                 .navigationBarTitle("")
                                 .navigationBarHidden(true)
                         }) {

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Common/BackButton.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Common/BackButton.swift
@@ -8,20 +8,28 @@
 import SwiftUI
 
 struct BackButton: View {
-    var body: some View {
-        Image(systemName: "arrow.left")
-            .font(.system(size: 24, weight: .bold))
-            .foregroundColor(universalAccentColor)
-            .overlay(
-                NavigationLink(destination: {
-                    FeedView()
-                        .navigationBarTitle("")
-                        .navigationBarHidden(true)
-                }) {
-                    Image(systemName: "arrow.left")
-                        .font(.system(size: 24, weight: .bold))
-                        .foregroundColor(universalAccentColor)
-                }
-            )
-    }
+	var source: BackButtonSourcePageType
+	var body: some View {
+		Image(systemName: "arrow.left")
+			.font(.system(size: 24, weight: .bold))
+			.foregroundColor(universalAccentColor)
+			.overlay(
+				NavigationLink(destination: {
+					switch source {
+					case .map:
+						MapView()
+							.navigationBarTitle("")
+							.navigationBarHidden(true)
+					case .feed:
+						FeedView()
+							.navigationBarTitle("")
+							.navigationBarHidden(true)
+					}
+				}) {
+					Image(systemName: "arrow.left")
+						.font(.system(size: 24, weight: .bold))
+						.foregroundColor(universalAccentColor)
+				}
+			)
+	}
 }


### PR DESCRIPTION
Created type for back button page source, then prop-drilled it through pages (perhaps bad design, but it's easily-understandable) to fix bug by conditionally going back to either FeedView or MapView

Kept it as a nullable variable, such that `FeedView` source callers won't have to specify this