### PR TITLE
81 fix popup dismissal

### DIFF
--- a/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
@@ -49,7 +49,6 @@ struct EventDescriptionView: View {
             .cornerRadius(universalRectangleCornerRadius)
         }
         .padding(.horizontal)
-//        .padding(.top, 200)
     }
 }
 

--- a/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
@@ -49,7 +49,7 @@ struct EventDescriptionView: View {
             .cornerRadius(universalRectangleCornerRadius)
         }
         .padding(.horizontal)
-        .padding(.top, 200)
+//        .padding(.top, 200)
     }
 }
 

--- a/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
@@ -25,73 +25,47 @@ struct FeedView: View {
 
     var body: some View {
         NavigationStack{
-            VStack{
-                Spacer()
-                HeaderView().padding(.top, 50)
-                Spacer()
-                TagsScrollView(tags: mockTags)
-                // TODO: implement logic here to adjust search results when the tag clicked is changed
-                Spacer()
-                Spacer()
-                VStack{
-                    eventsListView
-                    HStack (spacing: 35) {
-                        BottomNavButtonView(buttonType: .map)
-                        Spacer()
-						EventCreationButtonView(showingEventCreationPopup: $showingEventCreationPopup)
-                        Spacer()
-                        BottomNavButtonView(buttonType: .friends)
-                    }
-                }
-                .padding(.horizontal)
-            }
-            .padding()
-            .background(universalBackgroundColor)
-            .ignoresSafeArea(.container)
-			.dimmedBackground(
-				isActive: showingEventDescriptionPopup || showingEventCreationPopup
-			)
+			ZStack{
+				VStack{
+					Spacer()
+					HeaderView().padding(.top, 50)
+					Spacer()
+					TagsScrollView(tags: mockTags)
+					// TODO: implement logic here to adjust search results when the tag clicked is changed
+					Spacer()
+					Spacer()
+					VStack{
+						eventsListView
+						HStack (spacing: 35) {
+							BottomNavButtonView(buttonType: .map)
+							Spacer()
+							EventCreationButtonView(showingEventCreationPopup: $showingEventCreationPopup)
+							Spacer()
+							BottomNavButtonView(buttonType: .friends)
+						}
+					}
+					.padding(.horizontal)
+				}
+				.padding()
+				.background(universalBackgroundColor)
+				.ignoresSafeArea(.container)
+				.dimmedBackground(
+					isActive: showingEventDescriptionPopup || showingEventCreationPopup
+				)
+			}
+			if (showingEventDescriptionPopup) {
+				if let event = eventInPopup, let color = colorInPopup {
+					EventDescriptionView(
+						event: event,
+						users: User.mockUsers,
+						color: color
+					)
+				}
+			}
+			if (showingEventCreationPopup) {
+				EventCreationView(creatingUser: user.user)
+			}
         }
-        .popup(isPresented: $showingEventDescriptionPopup) {
-            if let event = eventInPopup, let color = colorInPopup {
-                EventDescriptionView(
-                    event: event,
-                    users: User.mockUsers,
-                    color: color
-                )
-            }
-        } customize: {
-            $0
-				.type(.floater(
-					verticalPadding: 20,
-					horizontalPadding: 20,
-					useSafeAreaInset: false
-				))
-				.appearFrom(.centerScale)
-				.disappearTo(.centerScale)
-				.closeOnTapOutside(true)
-				.dragToDismiss(false) // Prevent dismissal when dragging
-				.autohideIn(nil) // Disable auto-hide
-            // TODO: read up on the documentation: https://github.com/exyte/popupview
-            // so that the description view is dismissed upon clicking outside
-        }
-		.popup(isPresented: $showingEventCreationPopup) {
-			EventCreationView(creatingUser: user.user)
-		} customize: {
-			$0
-				.type(.floater(
-					verticalPadding: 20,
-					horizontalPadding: 20,
-					useSafeAreaInset: false
-				))
-				.appearFrom(.bottomSlide)
-				.disappearTo(.bottomSlide)
-				.closeOnTapOutside(true)
-				.dragToDismiss(false) // Prevent dismissal when dragging
-				.autohideIn(nil) // Disable auto-hide
-			// TODO: read up on the documentation: https://github.com/exyte/popupview
-			// so that the description view is dismissed upon clicking outside
-		}
     }
 }
 @available(iOS 17.0, *)

--- a/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
@@ -26,8 +26,8 @@ struct FeedView: View {
 	@State private var creationOffset: CGFloat = 1000
 
 	var body: some View {
+		ZStack {
 		NavigationStack {
-			ZStack {
 				VStack {
 					Spacer()
 					HeaderView().padding(.top, 50)
@@ -72,23 +72,12 @@ struct FeedView: View {
 							users: User.mockUsers,
 							color: color
 						)
-						.fixedSize(horizontal: false, vertical: true)
-						.padding()
-						.background(.white)
-						.clipShape(RoundedRectangle(cornerRadius: 20))
-						.overlay(alignment: .topTrailing) {
-							Button {
-								closeDescription()
-							} label: {
-								Image(systemName: "xmark")
-									.font(.title2)
-									.fontWeight(.medium)
-							}
-							.tint(.black)
-							.padding()
-						}
-						.shadow(radius: 20)
-						.padding(30)
+//						.fixedSize(horizontal: false, vertical: true)
+//						.padding()
+//						.background(.white)
+//						.clipShape(RoundedRectangle(cornerRadius: 20))
+//						.shadow(radius: 20)
+//						.padding(30)
 						.offset(x: 0, y: descriptionOffset)
 						.onAppear {
 							withAnimation(.spring()) {
@@ -109,23 +98,12 @@ struct FeedView: View {
 
 					EventCreationView(creatingUser: user.user)
 
-					.fixedSize(horizontal: false, vertical: true)
-					.padding()
+//					.fixedSize(horizontal: false, vertical: true)
+//					.padding()
 					.background(.white)
-					.clipShape(RoundedRectangle(cornerRadius: 20))
-					.overlay(alignment: .topTrailing) {
-						Button {
-							closeCreation()
-						} label: {
-							Image(systemName: "xmark")
-								.font(.title2)
-								.fontWeight(.medium)
-						}
-						.tint(.black)
-						.padding()
-					}
-					.shadow(radius: 20)
-					.padding(30)
+//					.clipShape(RoundedRectangle(cornerRadius: 20))
+//					.shadow(radius: 20)
+//					.padding(30)
 					.offset(x: 0, y: creationOffset)
 					.onAppear {
 						withAnimation(.spring()) {

--- a/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
@@ -72,12 +72,6 @@ struct FeedView: View {
 							users: User.mockUsers,
 							color: color
 						)
-//						.fixedSize(horizontal: false, vertical: true)
-//						.padding()
-//						.background(.white)
-//						.clipShape(RoundedRectangle(cornerRadius: 20))
-//						.shadow(radius: 20)
-//						.padding(30)
 						.offset(x: 0, y: descriptionOffset)
 						.onAppear {
 							withAnimation(.spring()) {
@@ -97,13 +91,6 @@ struct FeedView: View {
 						}
 
 					EventCreationView(creatingUser: user.user)
-
-//					.fixedSize(horizontal: false, vertical: true)
-//					.padding()
-					.background(.white)
-//					.clipShape(RoundedRectangle(cornerRadius: 20))
-//					.shadow(radius: 20)
-//					.padding(30)
 					.offset(x: 0, y: creationOffset)
 					.onAppear {
 						withAnimation(.spring()) {

--- a/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
@@ -5,28 +5,30 @@
 //  Created by Daniel Agapov on 11/3/24.
 //
 
-import PopupView
-
 import SwiftUI
 
 struct FeedView: View {
-    @EnvironmentObject var user: ObservableUser
-    @StateObject var viewModel: FeedViewModel = FeedViewModel(events: Event.mockEvents)
-    
-    @Namespace private var animation: Namespace.ID
-    
-    let mockTags: [FriendTag] = FriendTag.mockTags
-    
-    @State private var showingEventDescriptionPopup: Bool = false
-    @State private var eventInPopup: Event?
-    @State private var colorInPopup: Color?
+	@EnvironmentObject var user: ObservableUser
+	@StateObject var viewModel: FeedViewModel = FeedViewModel(
+		events: Event.mockEvents)
+
+	@Namespace private var animation: Namespace.ID
+
+	let mockTags: [FriendTag] = FriendTag.mockTags
+
+	@State private var showingEventDescriptionPopup: Bool = false
+	@State private var eventInPopup: Event?
+	@State private var colorInPopup: Color?
 
 	@State private var showingEventCreationPopup: Bool = false
 
-    var body: some View {
-        NavigationStack{
-			ZStack{
-				VStack{
+	@State private var descriptionOffset: CGFloat = 1000
+	@State private var creationOffset: CGFloat = 1000
+
+	var body: some View {
+		NavigationStack {
+			ZStack {
+				VStack {
 					Spacer()
 					HeaderView().padding(.top, 50)
 					Spacer()
@@ -34,12 +36,14 @@ struct FeedView: View {
 					// TODO: implement logic here to adjust search results when the tag clicked is changed
 					Spacer()
 					Spacer()
-					VStack{
+					VStack {
 						eventsListView
-						HStack (spacing: 35) {
+						HStack(spacing: 35) {
 							BottomNavButtonView(buttonType: .map)
 							Spacer()
-							EventCreationButtonView(showingEventCreationPopup: $showingEventCreationPopup)
+							EventCreationButtonView(
+								showingEventCreationPopup:
+									$showingEventCreationPopup)
 							Spacer()
 							BottomNavButtonView(buttonType: .friends)
 						}
@@ -50,23 +54,102 @@ struct FeedView: View {
 				.background(universalBackgroundColor)
 				.ignoresSafeArea(.container)
 				.dimmedBackground(
-					isActive: showingEventDescriptionPopup || showingEventCreationPopup
+					isActive: showingEventDescriptionPopup
+						|| showingEventCreationPopup
 				)
 			}
-			if (showingEventDescriptionPopup) {
+			if showingEventDescriptionPopup {
 				if let event = eventInPopup, let color = colorInPopup {
-					EventDescriptionView(
-						event: event,
-						users: User.mockUsers,
-						color: color
-					)
+					ZStack {
+						Color(.black)
+							.opacity(0.5)
+							.onTapGesture {
+								closeDescription()
+							}
+
+						EventDescriptionView(
+							event: event,
+							users: User.mockUsers,
+							color: color
+						)
+						.fixedSize(horizontal: false, vertical: true)
+						.padding()
+						.background(.white)
+						.clipShape(RoundedRectangle(cornerRadius: 20))
+						.overlay(alignment: .topTrailing) {
+							Button {
+								closeDescription()
+							} label: {
+								Image(systemName: "xmark")
+									.font(.title2)
+									.fontWeight(.medium)
+							}
+							.tint(.black)
+							.padding()
+						}
+						.shadow(radius: 20)
+						.padding(30)
+						.offset(x: 0, y: descriptionOffset)
+						.onAppear {
+							withAnimation(.spring()) {
+								descriptionOffset = 0
+							}
+						}
+					}
+					.ignoresSafeArea()
 				}
 			}
-			if (showingEventCreationPopup) {
-				EventCreationView(creatingUser: user.user)
+			if showingEventCreationPopup {
+				ZStack {
+					Color(.black)
+						.opacity(0.5)
+						.onTapGesture {
+							closeCreation()
+						}
+
+					EventCreationView(creatingUser: user.user)
+
+					.fixedSize(horizontal: false, vertical: true)
+					.padding()
+					.background(.white)
+					.clipShape(RoundedRectangle(cornerRadius: 20))
+					.overlay(alignment: .topTrailing) {
+						Button {
+							closeCreation()
+						} label: {
+							Image(systemName: "xmark")
+								.font(.title2)
+								.fontWeight(.medium)
+						}
+						.tint(.black)
+						.padding()
+					}
+					.shadow(radius: 20)
+					.padding(30)
+					.offset(x: 0, y: creationOffset)
+					.onAppear {
+						withAnimation(.spring()) {
+							creationOffset = 0
+						}
+					}
+				}
+				.ignoresSafeArea()
 			}
-        }
-    }
+		}
+	}
+	func closeDescription() {
+		withAnimation(.spring()) {
+			descriptionOffset = 1000
+			showingEventDescriptionPopup = false
+		}
+	}
+
+	func closeCreation() {
+		withAnimation(.spring()) {
+			creationOffset = 1000
+			showingEventCreationPopup = false
+		}
+	}
 }
 @available(iOS 17.0, *)
 #Preview {
@@ -78,37 +161,37 @@ struct FeedView: View {
 }
 
 extension FeedView {
-    var eventsListView: some View {
-        ScrollView(.vertical) {
-            LazyVStack(spacing: 15) {
-                ForEach(viewModel.events) {mockEvent in
-                    EventCardView(
-                        user: user.user,
-                        event: mockEvent,
-                        // TODO: change this logic to be based on the event in relation to which friend tag the creator belongs to
-                        color: eventColors.randomElement() ?? Color.blue
-                    ) { event, color in
-                        eventInPopup = event
-                        colorInPopup = color
-                        showingEventDescriptionPopup = true
-                    }
-                }
-            }
-        }
-    }
+	var eventsListView: some View {
+		ScrollView(.vertical) {
+			LazyVStack(spacing: 15) {
+				ForEach(viewModel.events) { mockEvent in
+					EventCardView(
+						user: user.user,
+						event: mockEvent,
+						// TODO: change this logic to be based on the event in relation to which friend tag the creator belongs to
+						color: eventColors.randomElement() ?? Color.blue
+					) { event, color in
+						eventInPopup = event
+						colorInPopup = color
+						showingEventDescriptionPopup = true
+					}
+				}
+			}
+		}
+	}
 }
 
 extension View {
-    func dimmedBackground(isActive: Bool) -> some View {
-        self.overlay(
-            Group {
-                if isActive {
-                    Color.black.opacity(0.5)
-                        .ignoresSafeArea()
-                        .transition(.opacity)
-                        .animation(.easeInOut, value: isActive)
-                }
-            }
-        )
-    }
+	func dimmedBackground(isActive: Bool) -> some View {
+		self.overlay(
+			Group {
+				if isActive {
+					Color.black.opacity(0.5)
+						.ignoresSafeArea()
+						.transition(.opacity)
+						.animation(.easeInOut, value: isActive)
+				}
+			}
+		)
+	}
 }

--- a/Spawn-App-iOS-SwiftUI/Views/MapView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/MapView.swift
@@ -26,7 +26,7 @@ struct MapView: View {
 	@State private var colorInPopup: Color?
 
 	@State private var showingEventCreationPopup: Bool = false
-	
+
 	@State private var descriptionOffset: CGFloat = 1000
 	@State private var creationOffset: CGFloat = 1000
 
@@ -115,17 +115,6 @@ struct MapView: View {
 						.padding()
 						.background(.white)
 						.clipShape(RoundedRectangle(cornerRadius: 20))
-						.overlay(alignment: .topTrailing) {
-							Button {
-								closeDescription()
-							} label: {
-								Image(systemName: "xmark")
-									.font(.title2)
-									.fontWeight(.medium)
-							}
-							.tint(.black)
-							.padding()
-						}
 						.shadow(radius: 20)
 						.padding(30)
 						.offset(x: 0, y: descriptionOffset)
@@ -152,17 +141,6 @@ struct MapView: View {
 						.padding()
 						.background(.white)
 						.clipShape(RoundedRectangle(cornerRadius: 20))
-						.overlay(alignment: .topTrailing) {
-							Button {
-								closeCreation()
-							} label: {
-								Image(systemName: "xmark")
-									.font(.title2)
-									.fontWeight(.medium)
-							}
-							.tint(.black)
-							.padding()
-						}
 						.shadow(radius: 20)
 						.padding(30)
 						.offset(x: 0, y: creationOffset)
@@ -189,6 +167,7 @@ struct MapView: View {
 			showingEventCreationPopup = false
 		}
 	}
+	
 	private func adjustRegionForEvents() {
 		guard !viewModel.events.isEmpty else { return }
 

--- a/Spawn-App-iOS-SwiftUI/Views/MapView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/MapView.swift
@@ -135,20 +135,23 @@ struct MapView: View {
 							closeCreation()
 						}
 
-					EventCreationView(creatingUser: user.user)
-
-						.fixedSize(horizontal: false, vertical: true)
-						.padding()
-						.background(.white)
-						.clipShape(RoundedRectangle(cornerRadius: 20))
-						.shadow(radius: 20)
-						.padding(30)
-						.offset(x: 0, y: creationOffset)
-						.onAppear {
-							withAnimation(.spring()) {
-								creationOffset = 0
+					VStack{
+						Spacer()
+						EventCreationView(creatingUser: user.user)
+							.fixedSize(horizontal: false, vertical: true)
+							.padding()
+							.background(.white)
+							.clipShape(RoundedRectangle(cornerRadius: 20))
+							.shadow(radius: 20)
+							.padding(30)
+							.offset(x: 0, y: creationOffset)
+							.onAppear {
+								withAnimation(.spring()) {
+									creationOffset = 0
+								}
 							}
-						}
+						Spacer()
+					}
 				}
 				.ignoresSafeArea()
 			}


### PR DESCRIPTION
Fixes UI issues laid out in #81. I did these in a messy way, without re-using the component, since when. 

I tried using `@ViewBuilder`, I ran into issues with having to upgrade our project Swift build version from 5 -> 6, which sprouted other things to take care of. 

So, I'll keep this PR simple and effective to get rid of the bug with dismissing popups upon clicking their content (instead of outside of their content, as they're supposed to behave). 