### PR TITLE
Fix event description popup

### DIFF
--- a/Spawn-App-iOS-SwiftUI/Models/ChatMessage.swift
+++ b/Spawn-App-iOS-SwiftUI/Models/ChatMessage.swift
@@ -30,6 +30,10 @@ class ChatMessage: Identifiable, Codable {
 }
 
 extension ChatMessage {
+	var formattedTimestamp: String {
+		return FormatterService.shared.timeAgo(from: timestamp)
+	}
+	
 	static let dateFormatter: DateFormatter = {
 		let formatter = DateFormatter()
 		formatter.dateStyle = .short

--- a/Spawn-App-iOS-SwiftUI/Models/Event.swift
+++ b/Spawn-App-iOS-SwiftUI/Models/Event.swift
@@ -55,17 +55,29 @@ class Event: Identifiable, Codable {
 }
 
 extension Event {
-	static let iso8601DateFormatter: ISO8601DateFormatter = {
-		let formatter = ISO8601DateFormatter()
-		formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-		return formatter
-	}()
+	static func dateFromTimeString(_ timeString: String) -> Date? {
+		let dateFormatter = DateFormatter()
+		dateFormatter.dateFormat = "h:mm a" // Parse time in 12-hour format with AM/PM
+		dateFormatter.timeZone = .current
+		dateFormatter.locale = .current
+
+		// Combine with today's date
+		if let parsedTime = dateFormatter.date(from: timeString) {
+			let calendar = Calendar.current
+			let now = Date()
+			return calendar.date(bySettingHour: calendar.component(.hour, from: parsedTime),
+								 minute: calendar.component(.minute, from: parsedTime),
+								 second: 0,
+								 of: now)
+		}
+		return nil
+	}
 
 	static let mockDinnerEvent: Event = Event(
 		id: UUID(),
 		title: "Dinner time!!!!!!",
-		startTime: Date(),
-		endTime: Date(),
+		startTime: dateFromTimeString("10:00 PM"),
+		endTime: dateFromTimeString("11:30 PM"),
 		location: Location(id: UUID(), name: "Gather - Place Vanier", latitude: 49.26468617023799, longitude: -123.25859833051356),
 		note: "let's eat!",
 		creator: User.jennifer,

--- a/Spawn-App-iOS-SwiftUI/Models/Event.swift
+++ b/Spawn-App-iOS-SwiftUI/Models/Event.swift
@@ -102,14 +102,14 @@ extension Event {
 				ChatMessage(
 					id: UUID(),
 					content: "yo guys, wya?",
-					timestamp: Date(),
+					timestamp: Date().addingTimeInterval(-30), // 30 seconds ago
 					userSender: User.danielAgapov,
 					eventId: mockDinnerEvent.id
 				),
 				ChatMessage(
 					id: UUID(),
 					content: "I just saw you",
-					timestamp: Date(),
+					timestamp: Date().addingTimeInterval(-120), // 2 minutes ago
 					userSender: User.danielLee,
 					eventId: mockDinnerEvent.id
 				)

--- a/Spawn-App-iOS-SwiftUI/Models/Event.swift
+++ b/Spawn-App-iOS-SwiftUI/Models/Event.swift
@@ -64,8 +64,8 @@ extension Event {
 	static let mockDinnerEvent: Event = Event(
 		id: UUID(),
 		title: "Dinner time!!!!!!",
-		startTime: iso8601DateFormatter.date(from: "2025-01-10T22:00:00Z"),
-		endTime: iso8601DateFormatter.date(from: "2025-01-10T23:30:00Z"),
+		startTime: Date(),
+		endTime: Date(),
 		location: Location(id: UUID(), name: "Gather - Place Vanier", latitude: 49.26468617023799, longitude: -123.25859833051356),
 		note: "let's eat!",
 		creator: User.jennifer,
@@ -82,7 +82,7 @@ extension Event {
 		Event(
 			id: UUID(),
 			title: "wanna run 5k with me?",
-			startTime: iso8601DateFormatter.date(from: "2025-01-11T16:00:00Z"),
+			startTime: Date(),
 			location: Location(id: UUID(), name: "Wesbrook Mall", latitude: 49.25997722657244, longitude: -123.23986523529379),
 			creator: User.danielAgapov,
 			participants: [User.danielAgapov, User.jennifer, User.shannon, User.haley, User.danielLee],
@@ -106,7 +106,7 @@ extension Event {
 		Event(
 			id: UUID(),
 			title: "playing basketball!!!",
-			endTime: iso8601DateFormatter.date(from: "2025-01-11T19:00:00Z"),
+			endTime: Date(),
 			location: Location(id: UUID(), name: "UBC Student Recreation Centre", latitude: 49.2687302352351, longitude: -123.24897582888525),
 			note: "let's play basketball!",
 			creator: User.danielAgapov
@@ -114,8 +114,8 @@ extension Event {
 		Event(
 			id: UUID(),
 			title: "Im painting rn lol",
-			startTime: iso8601DateFormatter.date(from: "2025-01-11T10:00:00Z"),
-			endTime: iso8601DateFormatter.date(from: "2025-01-11T11:30:00Z"),
+			startTime: Date(),
+			endTime: Date(),
 			location: Location(id: UUID(), name: "Ross Drive - Wesbrook Mall", latitude: 49.25189587512135, longitude: -123.237051932404),
 			creator: User.shannon,
 			participants: [User.danielLee]
@@ -123,24 +123,24 @@ extension Event {
 		Event(
 			id: UUID(),
 			title: "Grabbing Udon",
-			startTime: iso8601DateFormatter.date(from: "2025-01-11T12:00:00Z"),
-			endTime: iso8601DateFormatter.date(from: "2025-01-11T14:30:00Z"),
+			startTime: Date(),
+			endTime: Date(),
 			location: Location(id: UUID(), name: "Marugame Udon", latitude: 49.28032597998406, longitude: -123.11026665974741),
 			creator: User.danielAgapov
 		),
 		Event(
 			id: UUID(),
 			title: "Calendar Party",
-			startTime: iso8601DateFormatter.date(from: "2025-01-11T23:00:00Z"),
-			endTime: iso8601DateFormatter.date(from: "2025-01-12T02:30:00Z"),
+			startTime: Date(),
+			endTime: Date(),
 			location: Location(id: UUID(), name: "The Pit - Nest", latitude: 49.26694140754859, longitude: -123.25036565366581),
 			creator: User.danielLee
 		),
 		Event(
 			id: UUID(),
 			title: "Gym - Leg Day",
-			startTime: iso8601DateFormatter.date(from: "2025-01-11T10:00:00Z"),
-			endTime: iso8601DateFormatter.date(from: "2025-01-11T11:30:00Z"),
+			startTime: Date(),
+			endTime: Date(),
 			location: Location(id: UUID(), name: "UBC Student Recreation Centre", latitude: 49.2687302352351, longitude: -123.24897582888525),
 			creator: User.michael
 		)

--- a/Spawn-App-iOS-SwiftUI/Services/FormatterService.swift
+++ b/Spawn-App-iOS-SwiftUI/Services/FormatterService.swift
@@ -43,4 +43,26 @@ class FormatterService {
 			return "No Time Available"
 		}
 	}
+
+	func timeAgo(from date: Date) -> String {
+		let now = Date()
+		let secondsAgo = Int(now.timeIntervalSince(date))
+
+		let minute = 60
+		let hour = 3600
+		let day = 86400
+
+		if secondsAgo < minute {
+			return secondsAgo == 1 ? "1 second ago" : "\(secondsAgo) seconds ago"
+		} else if secondsAgo < hour {
+			let minutes = secondsAgo / minute
+			return minutes == 1 ? "1 minute ago" : "\(minutes) minutes ago"
+		} else if secondsAgo < day {
+			let hours = secondsAgo / hour
+			return hours == 1 ? "1 hour ago" : "\(hours) hours ago"
+		} else {
+			let days = secondsAgo / day
+			return days == 1 ? "1 day ago" : "\(days) days ago"
+		}
+	}
 }

--- a/Spawn-App-iOS-SwiftUI/Services/FormatterService.swift
+++ b/Spawn-App-iOS-SwiftUI/Services/FormatterService.swift
@@ -5,6 +5,8 @@
 //  Created by Daniel Agapov on 11/14/24.
 //
 
+import Foundation
+
 class FormatterService {
     static let shared: FormatterService = FormatterService()
     
@@ -24,20 +26,17 @@ class FormatterService {
         return ""
     }
 
-	public func formatEventTime(event: Event) -> String {
-		var eventTimeDisplayStringLocal: String = ""
-		if let eventStartTime = event.startTime {
-			if let eventEndTime = event.endTime {
-				eventTimeDisplayStringLocal += "\(eventStartTime) — \(eventEndTime)"
-			} else {
-				eventTimeDisplayStringLocal = "Starts at \(eventStartTime)"
-			}
-		} else {
-			// no start time
-			if let eventEndTime = event.endTime {
-				eventTimeDisplayStringLocal = "Ends at \(eventEndTime)"
-			}
+	func formatEventTime(event: Event) -> String {
+		
+		guard let startTime = event.startTime else { return "No Time Available" }
+		let dateFormatter = DateFormatter()
+		dateFormatter.dateFormat = "h:mm a"
+		dateFormatter.timeZone = .current
+
+		if let endTime = event.endTime,
+		   Calendar.current.isDate(startTime, inSameDayAs: endTime) {
+			return "\(dateFormatter.string(from: startTime)) - \(dateFormatter.string(from: endTime))"
 		}
-		return eventTimeDisplayStringLocal
+		return dateFormatter.string(from: startTime)
 	}
 }

--- a/Spawn-App-iOS-SwiftUI/Services/FormatterService.swift
+++ b/Spawn-App-iOS-SwiftUI/Services/FormatterService.swift
@@ -27,16 +27,20 @@ class FormatterService {
     }
 
 	func formatEventTime(event: Event) -> String {
-		
-		guard let startTime = event.startTime else { return "No Time Available" }
 		let dateFormatter = DateFormatter()
 		dateFormatter.dateFormat = "h:mm a"
 		dateFormatter.timeZone = .current
 
-		if let endTime = event.endTime,
-		   Calendar.current.isDate(startTime, inSameDayAs: endTime) {
-			return "\(dateFormatter.string(from: startTime)) - \(dateFormatter.string(from: endTime))"
+		if let startTime = event.startTime {
+			if let endTime = event.endTime,
+				Calendar.current.isDate(startTime, inSameDayAs: endTime) {
+				return "\(dateFormatter.string(from: startTime)) - \(dateFormatter.string(from: endTime))"
+			}
+			return "Starts at \(dateFormatter.string(from: startTime))"
+		} else if let endTime = event.endTime {
+			return "Ends at \(dateFormatter.string(from: endTime))"
+		} else {
+			return "No Time Available"
 		}
-		return dateFormatter.string(from: startTime)
 	}
 }

--- a/Spawn-App-iOS-SwiftUI/ViewModels/Event/EventInfoViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/Event/EventInfoViewModel.swift
@@ -8,22 +8,18 @@
 import Foundation
 
 class EventInfoViewModel: ObservableObject {
-    @Published var eventInfoDisplayString: String
+	@Published var eventInfoDisplayString: String
 	@Published var imageSystemName: String
 
-    init(event: Event, eventInfoType: EventInfoType) {
+	init(event: Event, eventInfoType: EventInfoType) {
 		switch eventInfoType {
 			case .location:
 				imageSystemName = "map"
-				if let eventLocation = event.location?.name {
-					self.eventInfoDisplayString = eventLocation
-				} else {
-					// nil event location (should be error?)
-					self.eventInfoDisplayString = "No Location"
-				}
+				self.eventInfoDisplayString = event.location?.name ?? "No Location"
 			case .time:
 				imageSystemName = "clock"
 				self.eventInfoDisplayString = FormatterService.shared.formatEventTime(event: event)
 		}
-    }
+	}
 }
+

--- a/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
@@ -8,78 +8,84 @@
 import SwiftUI
 
 struct EventDescriptionView: View {
-    @ObservedObject var viewModel: EventDescriptionViewModel
-    var color: Color
-    
-    init(event: Event, users: [User], color: Color) {
-        self.viewModel = EventDescriptionViewModel(event: event, users: users)
-        self.color = color
-    }
-    
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                // Title and Time Information
-                EventCardTopRowView(event: viewModel.event)
-                
-                HStack {
-                    VStack(alignment: .leading, spacing: 10) {
-                        EventInfoView(event: viewModel.event, eventInfoType: .time)
-                        EventInfoView(event: viewModel.event, eventInfoType: .location)
-                    }
-                    .foregroundColor(.white)
-                    
-                    Spacer() // Ensures alignment but doesn't add spacing below the content
-                }
-                
-                // Note
-                if let note = viewModel.event.note {
-                    Text("Note: \(note)")
-                        .font(.body)
-                }
-                
-                if let chatMessages = viewModel.event.chatMessages {
-                    Text("\(chatMessages.count) replies")
-                }
-                
-                chatMessagesView
-            }
-            .padding(20)
-            .background(color)
-            .cornerRadius(universalRectangleCornerRadius)
-        }
-        .padding(.horizontal)
-    }
+	@ObservedObject var viewModel: EventDescriptionViewModel
+	var color: Color
+
+	init(event: Event, users: [User], color: Color) {
+		self.viewModel = EventDescriptionViewModel(event: event, users: users)
+		self.color = color
+	}
+
+	var body: some View {
+		ScrollView {
+			VStack(alignment: .leading, spacing: 20) {
+				// Title and Time Information
+				EventCardTopRowView(event: viewModel.event)
+
+				HStack {
+					VStack(alignment: .leading, spacing: 10) {
+						EventInfoView(
+							event: viewModel.event, eventInfoType: .time)
+						EventInfoView(
+							event: viewModel.event, eventInfoType: .location)
+					}
+					.foregroundColor(.white)
+
+					Spacer()  // Ensures alignment but doesn't add spacing below the content
+				}
+
+				// Note
+				if let note = viewModel.event.note {
+					Text("Note: \(note)")
+						.font(.body)
+				}
+
+				if let chatMessages = viewModel.event.chatMessages {
+					Text("\(chatMessages.count) replies")
+				}
+
+				chatMessagesView
+			}
+			.padding(20)
+			.background(color)
+			.cornerRadius(universalRectangleCornerRadius)
+		}
+		.padding(.horizontal)
+		.padding(.vertical, 200)
+	}
 }
 
 extension EventDescriptionView {
-    var chatMessagesView: some View {
-        ScrollView(.vertical) {
-            LazyVStack(spacing: 15) {
-                if let chatMessages = viewModel.event.chatMessages {
-                    // TODO: remove this logic out of the view, and into view model
-                    ForEach(chatMessages) { chatMessage in
-                        let user: User = chatMessage.userSender
-                        HStack{
-                            if let profilePictureString = user.profilePicture {
-                                Image(profilePictureString)
-                                    .ProfileImageModifier(imageType: .chatMessage)
-                            }
-                            VStack{
-                                Text(user.username)
-                                Text(chatMessage.content)
-                            }
-                            Spacer()
-                            HStack{
-								Text(ChatMessage.dateFormatter.string(from: chatMessage.timestamp))
-                                // TODO: add logic later, to either use heart.fill or just heart,
-                                // based on whether current user is in the chat message's likedBy array
-                                Image(systemName: "heart")
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+	var chatMessagesView: some View {
+		ScrollView(.vertical) {
+			LazyVStack(spacing: 15) {
+				if let chatMessages = viewModel.event.chatMessages {
+					// TODO: remove this logic out of the view, and into view model
+					ForEach(chatMessages) { chatMessage in
+						let user: User = chatMessage.userSender
+						HStack {
+							if let profilePictureString = user.profilePicture {
+								Image(profilePictureString)
+									.ProfileImageModifier(
+										imageType: .chatMessage)
+							}
+							VStack {
+								Text(user.username)
+								Text(chatMessage.content)
+							}
+							Spacer()
+							HStack {
+								Text(
+									ChatMessage.dateFormatter.string(
+										from: chatMessage.timestamp))
+								// TODO: add logic later, to either use heart.fill or just heart,
+								// based on whether current user is in the chat message's likedBy array
+								Image(systemName: "heart")
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
@@ -75,9 +75,7 @@ extension EventDescriptionView {
 							}
 							Spacer()
 							HStack {
-								Text(
-									ChatMessage.dateFormatter.string(
-										from: chatMessage.timestamp))
+								Text(chatMessage.formattedTimestamp)
 								// TODO: add logic later, to either use heart.fill or just heart,
 								// based on whether current user is in the chat message's likedBy array
 								Image(systemName: "heart")

--- a/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
@@ -14,8 +14,6 @@ struct FeedView: View {
 
 	@Namespace private var animation: Namespace.ID
 
-	let mockTags: [FriendTag] = FriendTag.mockTags
-
 	@State private var showingEventDescriptionPopup: Bool = false
 	@State private var eventInPopup: Event?
 	@State private var colorInPopup: Color?


### PR DESCRIPTION
<img width="250" alt="image" src="https://github.com/user-attachments/assets/2031dd8f-d523-4051-a5c9-85ae5f309986" />

<img width="265" alt="image" src="https://github.com/user-attachments/assets/9fce00fb-7eeb-43a1-9d5a-04440b30a6a1" />


- Padding changes
- Event time `isoDateFormatter` -> `Date()`
- `EventInfoView` time formatting improvements, with new change from `string` -> `Date` data type
- Fixed event start time and end time formatting from `Date` objects, with old mock data equivalents
- Simplified some View Model logic
- Preserved event end time & start time logic in `FormatterService.swift`, while implementing `Date` logic
- Fixed chat message timestamp formatting