### PR TITLE
Friend Tag Event Filtering + Friend Tag Friend Addition/Removal Modified

### DIFF
--- a/Spawn-App-iOS-SwiftUI/Services/API/APIService.swift
+++ b/Spawn-App-iOS-SwiftUI/Services/API/APIService.swift
@@ -237,3 +237,8 @@ class APIService: IAPIService {
 		}
 	}
 }
+
+// since the PUT requests don't need any `@RequestBody` in the back-end
+struct EmptyRequestBody: Codable {}
+// for empty responses from requests:
+struct EmptyResponse: Codable {}

--- a/Spawn-App-iOS-SwiftUI/ViewModels/FeedViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/FeedViewModel.swift
@@ -8,8 +8,9 @@
 import Foundation
 
 class FeedViewModel: ObservableObject {
-    @Published var events: [Event] = []
+	@Published var events: [Event] = []
 	@Published var tags: [FriendTag] = []
+	@Published var activeTag: FriendTag?
 
 	var apiService: IAPIService
 	var userId: UUID
@@ -17,49 +18,70 @@ class FeedViewModel: ObservableObject {
 	init(apiService: IAPIService, userId: UUID) {
 		self.apiService = apiService
 		self.userId = userId
-    }
+		self._activeTag = Published(initialValue: tags.first)  // this will automatically null-check
+	}
 
-	func fetchAllData() async -> Void {
+	func fetchAllData() async {
 		await fetchEventsForUser()
 		await fetchTagsForUser()
 	}
 
-	func fetchEventsForUser() async -> Void {
-		// /api/v1/events/feedEvents/{requestingUserId}
-		if let url = URL(string: APIService.baseURL + "events/feedEvents/\(userId.uuidString)") {
-			do {
-				let fetchedEvents: [Event] = try await self.apiService.fetchData(
-					from: url, parameters: nil
-				)
+	func fetchEventsForUser() async {
+		// Declare `setUrl` as an optional URL
+		var setUrl: URL?
 
-				// Ensure updating on the main thread
-				await MainActor.run {
-					self.events = fetchedEvents
-				}
-			} catch {
-				if let statusCode = apiService.errorStatusCode, apiService.errorStatusCode != 404 {
-					print("Invalid status code from response: \(statusCode)")
-					print(apiService.errorMessage ?? "")
-				}
-				await MainActor.run {
-					self.events = []
-				}
+		if let unwrappedActiveTag = activeTag, !unwrappedActiveTag.isEveryone {
+			// Full path: /api/v1/events/friendTag/{friendTagFilterId}
+			setUrl = URL(string: APIService.baseURL + "events/friendTag/\(unwrappedActiveTag.id)")
+		} else {
+			// Path: /api/v1/events/feedEvents/{requestingUserId}
+			setUrl = URL(string: APIService.baseURL + "events/feedEvents/\(userId)")
+		}
+
+		// Safely unwrap `setUrl` using `guard let`
+		guard let url = setUrl else {
+			print("Failed to construct URL")
+			return
+		}
+
+		do {
+			let fetchedEvents: [Event] = try await self.apiService.fetchData(
+				from: url, parameters: nil
+			)
+
+			// Ensure updating on the main thread
+			await MainActor.run {
+				self.events = fetchedEvents
+			}
+		} catch {
+			if let statusCode = apiService.errorStatusCode, apiService.errorStatusCode != 404
+			{
+				print("Invalid status code from response: \(statusCode)")
+				print(apiService.errorMessage ?? "")
+			}
+			await MainActor.run {
+				self.events = []
 			}
 		}
 	}
 
-	func fetchTagsForUser() async -> Void {
+	func fetchTagsForUser() async {
 		// /api/v1/friendTags/owner/{ownerId}?full=full
-		if let url = URL(string: APIService.baseURL + "friendTags/owner/\(userId.uuidString)") {
+		if let url = URL(
+			string: APIService.baseURL + "friendTags/owner/\(userId)"
+		) {
 			do {
-				let fetchedTags: [FriendTag] = try await self.apiService.fetchData(from: url, parameters: ["full": "true"])
+				let fetchedTags: [FriendTag] = try await self.apiService
+					.fetchData(from: url, parameters: ["full": "true"])
 
 				// Ensure updating on the main thread
 				await MainActor.run {
 					self.tags = fetchedTags
+					self.activeTag = fetchedTags.first
 				}
 			} catch {
-				if let statusCode = apiService.errorStatusCode, apiService.errorStatusCode != 404 {
+				if let statusCode = apiService.errorStatusCode
+				{
 					print("Invalid status code from response: \(statusCode)")
 					print(apiService.errorMessage ?? "")
 				}

--- a/Spawn-App-iOS-SwiftUI/ViewModels/FeedViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/FeedViewModel.swift
@@ -19,6 +19,11 @@ class FeedViewModel: ObservableObject {
 		self.userId = userId
     }
 
+	func fetchAllData() async -> Void {
+		await fetchEventsForUser()
+		await fetchTagsForUser()
+	}
+
 	func fetchEventsForUser() async -> Void {
 		// /api/v1/events/feedEvents/{requestingUserId}
 		if let url = URL(string: APIService.baseURL + "events/feedEvents/\(userId.uuidString)") {

--- a/Spawn-App-iOS-SwiftUI/ViewModels/FriendRequestViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/FriendRequestViewModel.swift
@@ -44,9 +44,7 @@ class FriendRequestViewModel: ObservableObject {
 	}
 }
 
-// since the PUT requests don't need any `@RequestBody` in the back-end
-struct EmptyRequestBody: Codable {}
-struct EmptyResponse: Codable {}
+
 
 enum FriendRequestAction: String {
 	case accept = "accept"

--- a/Spawn-App-iOS-SwiftUI/ViewModels/TagsViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/TagsViewModel.swift
@@ -11,6 +11,7 @@ class TagsViewModel: ObservableObject {
 	@Published var tags: [FriendTag] = []
 	@Published var creationMessage: String = ""
 	@Published var deletionMessage: String = ""
+	@Published var friendRemovalMessage: String = ""
 
 	var apiService: IAPIService
 	var userId: UUID
@@ -87,7 +88,7 @@ class TagsViewModel: ObservableObject {
 						string: APIService.baseURL + "friendTags/\(newTag.id)")
 				else { return }
 				let update: FriendTagCreationDTO = try await self.apiService
-						.updateData(newTag, to: url, parameters: nil)
+					.updateData(newTag, to: url, parameters: nil)
 			}
 		} catch {
 			await MainActor.run {
@@ -113,6 +114,29 @@ class TagsViewModel: ObservableObject {
 				await MainActor.run {
 					deletionMessage =
 						"There was an error deleting the tag. Please try again."
+					print(apiService.errorMessage ?? "")
+				}
+			}
+		}
+		await fetchTags()
+	}
+
+	func removeFriendFromFriendTag(friendUserId: UUID, friendTagId: UUID) async
+	{
+		if let url = URL(
+			string: APIService.baseURL + "friendTags/\(friendTagId)")
+		{
+			do {
+				try await self.apiService.sendData(EmptyBody(),
+to: url,
+					parameters: [
+						"friendTagAction": "removeFriend",
+						"userId": friendUserId.uuidString,
+					])
+			} catch {
+				await MainActor.run {
+					friendRemovalMessage =
+						"There was an error removing your friend from the friend tag. Please try again."
 					print(apiService.errorMessage ?? "")
 				}
 			}

--- a/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
@@ -33,6 +33,7 @@ struct FeedView: View {
 				? MockAPIService(userId: user.id) : APIService(), userId: user.id))
 	}
 
+
 	var body: some View {
 		ZStack {
 			NavigationStack {
@@ -40,8 +41,10 @@ struct FeedView: View {
 					Spacer()
 					HeaderView(user: user).padding(.top, 50)
 					Spacer()
-					TagsScrollView(tags: viewModel.tags)
-					// TODO: implement logic here to adjust search results when the tag clicked is changed
+					TagsScrollView(
+						tags: viewModel.tags,
+						activeTag: $viewModel.activeTag
+					)
 					Spacer()
 					Spacer()
 					VStack {

--- a/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
@@ -30,9 +30,9 @@ struct FeedView: View {
 		_viewModel = StateObject(
 			wrappedValue: FeedViewModel(
 				apiService: MockAPIService.isMocking
-				? MockAPIService(userId: user.id) : APIService(), userId: user.id))
+					? MockAPIService(userId: user.id) : APIService(),
+				userId: user.id))
 	}
-
 
 	var body: some View {
 		ZStack {
@@ -67,6 +67,11 @@ struct FeedView: View {
 					await viewModel.fetchAllData()
 				}
 			}
+			.onChange(of: viewModel.activeTag) { _ in
+				Task {
+					await viewModel.fetchEventsForUser()
+				}
+			}
 			if showingEventDescriptionPopup {
 				eventDescriptionPopupView
 			}
@@ -94,7 +99,7 @@ struct FeedView: View {
 
 extension FeedView {
 	var eventDescriptionPopupView: some View {
-		Group{
+		Group {
 			if let event = eventInPopup, let color = colorInPopup {
 				ZStack {
 					Color(.black)
@@ -102,7 +107,7 @@ extension FeedView {
 						.onTapGesture {
 							closeDescription()
 						}
-					
+
 					EventDescriptionView(
 						event: event,
 						users: event.participantUsers,
@@ -116,7 +121,12 @@ extension FeedView {
 					// brute-force algorithm I wrote
 					.padding(
 						.vertical,
-						max(330, 330 - CGFloat(100 * (event.chatMessages?.count ?? 0)) - CGFloat (event.note != nil ? 200 : 0))
+						max(
+							330,
+							330
+								- CGFloat(
+									100 * (event.chatMessages?.count ?? 0))
+								- CGFloat(event.note != nil ? 200 : 0))
 					)
 				}
 				.ignoresSafeArea()
@@ -164,7 +174,10 @@ extension FeedView {
 						EventCardView(
 							user: user,
 							event: event,
-							color: Color(hex: event.eventFriendTagColorHexCodeForRequestingUser ?? eventColorHexCodes[0])
+							color: Color(
+								hex: event
+									.eventFriendTagColorHexCodeForRequestingUser
+									?? eventColorHexCodes[0])
 						) { event, color in
 							eventInPopup = event
 							colorInPopup = color

--- a/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
@@ -61,8 +61,7 @@ struct FeedView: View {
 			.background(universalBackgroundColor)
 			.onAppear {
 				Task {
-					await viewModel.fetchEventsForUser()
-					await viewModel.fetchTagsForUser()
+					await viewModel.fetchAllData()
 				}
 			}
 			if showingEventDescriptionPopup {

--- a/Spawn-App-iOS-SwiftUI/Views/MapView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/MapView.swift
@@ -47,7 +47,7 @@ struct MapView: View {
 					mapView
 					VStack {
 						VStack {
-							TagsScrollView(tags: viewModel.tags)
+							TagsScrollView(tags: viewModel.tags, activeTag: $viewModel.activeTag)
 						}
 						.padding(.horizontal)
 						.padding(.top, 20)

--- a/Spawn-App-iOS-SwiftUI/Views/MapView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/MapView.swift
@@ -67,8 +67,7 @@ struct MapView: View {
 			.onAppear {
 				adjustRegionForEvents()
 				Task {
-					await viewModel.fetchEventsForUser()
-					await viewModel.fetchTagsForUser()
+					await viewModel.fetchAllData()
 				}
 			}
 			if showingEventDescriptionPopup {

--- a/Spawn-App-iOS-SwiftUI/Views/MapView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/MapView.swift
@@ -47,7 +47,9 @@ struct MapView: View {
 					mapView
 					VStack {
 						VStack {
-							TagsScrollView(tags: viewModel.tags, activeTag: $viewModel.activeTag)
+							TagsScrollView(
+								tags: viewModel.tags,
+								activeTag: $viewModel.activeTag)
 						}
 						.padding(.horizontal)
 						.padding(.top, 20)
@@ -68,6 +70,11 @@ struct MapView: View {
 				adjustRegionForEvents()
 				Task {
 					await viewModel.fetchAllData()
+				}
+			}
+			.onChange(of: viewModel.activeTag) { _ in
+				Task {
+					await viewModel.fetchEventsForUser()
 				}
 			}
 			if showingEventDescriptionPopup {
@@ -154,9 +161,7 @@ extension MapView {
 								.frame(width: 60, height: 60)
 								.foregroundColor(universalAccentColor)
 
-
-							if let pfpUrl = event.creatorUser?.profilePicture
-							{
+							if let pfpUrl = event.creatorUser?.profilePicture {
 								AsyncImage(url: URL(string: pfpUrl)) {
 									image in
 									image
@@ -257,4 +262,3 @@ struct Triangle: Shape {
 		return path
 	}
 }
-

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/FeedSubViews/TagsScrollView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/FeedSubViews/TagsScrollView.swift
@@ -9,21 +9,21 @@ import SwiftUI
 
 struct TagsScrollView: View {
     var tags: [FriendTag]
-    @State private var activeTag: FriendTag?
+    @Binding private var activeTag: FriendTag?
     @Namespace private var animation: Namespace.ID
 
-	init(tags: [FriendTag]) {
+	init(tags: [FriendTag], activeTag: Binding<FriendTag?>) {
 		self.tags = tags
-		self._activeTag = State(initialValue: tags.first) // this will automatically null-check
+		self._activeTag = activeTag
 	}
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 12) {
                 ForEach(tags, id: \.self) { tag in
-					if activeTag != nil {
-						TagButtonView(tag: tag, activeTag: $activeTag, animation: animation)
-					}
+					TagButtonView(tag: tag, activeTag: $activeTag, animation: animation)
+						.onAppear {
+						}
                 }
             }
             .padding(.top, 10)

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tabs/FriendsTabView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tabs/FriendsTabView.swift
@@ -332,15 +332,17 @@ struct FriendsTabView: View {
 				LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
 					ForEach(friend.associatedFriendTagsToOwner ?? []) {
 						friendTag in
-						Text(friendTag.displayName)
-							.font(.system(size: 10, weight: .medium))
-							.padding(.horizontal, 12)
-							.padding(.vertical, 6)
-							.background(Color(hex: friendTag.colorHexCode))
-							.foregroundColor(.white)
-							.cornerRadius(12)
-							.lineLimit(1)  // Ensure text doesn't wrap
-							.truncationMode(.tail)  // Truncate with "..." if text is too long
+						if !friendTag.isEveryone {
+							Text(friendTag.displayName)
+								.font(.system(size: 10, weight: .medium))
+								.padding(.horizontal, 12)
+								.padding(.vertical, 6)
+								.background(Color(hex: friendTag.colorHexCode))
+								.foregroundColor(.white)
+								.cornerRadius(12)
+								.lineLimit(1)  // Ensure text doesn't wrap
+								.truncationMode(.tail)  // Truncate with "..." if text is too long
+						}
 					}
 				}
 			}

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/FriendContainer.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/FriendContainer.swift
@@ -25,7 +25,7 @@ struct FriendContainer: View {
             ScrollView {
                 if let friends = friendTag.friends, !friends.isEmpty {
                     ForEach(friends) { friend in
-                        FriendRow(friend: friend)
+						FriendRow(friend: friend, friendTag: friendTag)
                             .padding(.horizontal)
                     }
                 } else {

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/FriendRow.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/FriendRow.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct FriendRow: View {
+	@EnvironmentObject var viewModel: TagsViewModel
     var friend: User
-    var action: () -> Void = {}
+	var friendTag: FriendTag
 
     var body: some View {
         HStack {
@@ -35,7 +36,11 @@ struct FriendRow: View {
             Text(friend.username)
                 .font(.headline)
             Spacer()
-            Button(action: action) {
+			Button(action: {
+				Task{
+					await viewModel.removeFriendFromFriendTag(friendUserId: friend.id, friendTagId: friendTag.id)
+				}
+			}) {
                 Image(systemName: "xmark")
             }
         }

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/TagRow.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/TagRow.swift
@@ -22,9 +22,13 @@ struct TagRow: View {
 
 	var addFriendToTagButtonPressedCallback: (UUID) -> Void
 
-	init(friendTag: FriendTag, addFriendToTagButtonPressedCallback: @escaping (UUID) -> Void) {
+	init(
+		friendTag: FriendTag,
+		addFriendToTagButtonPressedCallback: @escaping (UUID) -> Void
+	) {
 		self.friendTag = friendTag
-		self.addFriendToTagButtonPressedCallback = addFriendToTagButtonPressedCallback
+		self.addFriendToTagButtonPressedCallback =
+			addFriendToTagButtonPressedCallback
 		self._titleText = State(initialValue: friendTag.displayName)
 		self._editedTitleText = State(initialValue: friendTag.displayName)
 		self._editedColorHexCode = State(initialValue: friendTag.colorHexCode)
@@ -57,9 +61,9 @@ struct TagRow: View {
 						}) {
 							Image(
 								systemName: isEditingTitle
-								? "checkmark" : "pencil")
+									? "checkmark" : "pencil")
 						}
-						
+
 						if isEditingTitle {
 							Button(action: {
 								showDeleteAlert = true
@@ -78,7 +82,8 @@ struct TagRow: View {
 				.fontWeight(.semibold)
 
 				Spacer()
-				TagFriendsView(friends: friendTag.friends, isExpanded: $isExpanded)
+				TagFriendsView(
+					friends: friendTag.friends, isExpanded: $isExpanded)
 			}
 			.padding()
 			.background(
@@ -86,13 +91,17 @@ struct TagRow: View {
 					.fill(Color(hex: editedColorHexCode))
 			)
 			if isExpanded {
-				ExpandedTagView(currentSelectedColorHexCode: $editedColorHexCode,friendTag: friendTag, isEditingTag: $isEditingTitle, addFriendToTagButtonPressedCallback: addFriendToTagButtonPressedCallback)
+				ExpandedTagView(
+					currentSelectedColorHexCode: $editedColorHexCode,
+					friendTag: friendTag, isEditingTag: $isEditingTitle,
+					addFriendToTagButtonPressedCallback:
+						addFriendToTagButtonPressedCallback)
 			}
 		}
-		.alert("Delete Friend Tag", isPresented: $showDeleteAlert) { // Add the alert
+		.alert("Delete Friend Tag", isPresented: $showDeleteAlert) {  // Add the alert
 			Button("Yes", role: .destructive) {
 				Task {
-					await viewModel.deleteTag(id: friendTag.id) // Call the delete method
+					await viewModel.deleteTag(id: friendTag.id)  // Call the delete method
 				}
 			}
 			Button("No, I'll keep it", role: .cancel) {}
@@ -150,6 +159,11 @@ struct TagFriendsView: View {
 				Image(systemName: "plus.circle")
 					.font(.system(size: 24))
 					.foregroundColor(.white)
+					.clipShape(Circle())
+					.background(
+						Circle()
+							.stroke(universalAccentColor, lineWidth: 2)
+					)
 			}
 		}
 	}

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/TagRow.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/TagRow.swift
@@ -36,60 +36,66 @@ struct TagRow: View {
 
 	var body: some View {
 		VStack {
-			HStack {
+			Button(action: {
+				isExpanded = true
+			}) {
 				HStack {
-					if isExpanded {
-						titleView
+					HStack {
+						if isExpanded {
+							titleView
 
-						Button(action: {
-							if isEditingTitle {
-								// this means they're submitting the new title/color
-								Task {
-									// Attempt to update the tag
-									await viewModel.upsertTag(
-										id: friendTag.id,
-										displayName: editedTitleText,
-										colorHexCode: editedColorHexCode,
-										upsertAction: .update
-									)
-
-									isEditingTitle = false
-								}
-							} else {
-								isEditingTitle = true
-							}
-						}) {
-							Image(
-								systemName: isEditingTitle
-									? "checkmark" : "pencil")
-						}
-
-						if isEditingTitle {
 							Button(action: {
-								showDeleteAlert = true
+								if isEditingTitle {
+									// this means they're submitting the new title/color
+									Task {
+										// Attempt to update the tag
+										await viewModel.upsertTag(
+											id: friendTag.id,
+											displayName: editedTitleText,
+											colorHexCode: editedColorHexCode,
+											upsertAction: .update
+										)
+
+										isEditingTitle = false
+									}
+								} else {
+									isEditingTitle = true
+								}
 							}) {
-								Image(systemName: "trash")
+								Image(
+									systemName: isEditingTitle
+										? "checkmark" : "pencil")
 							}
 
+							if isEditingTitle {
+								Button(action: {
+									showDeleteAlert = true
+								}) {
+									Image(systemName: "trash")
+								}
+
+							}
+
+						} else {
+							Text(friendTag.displayName)
 						}
-
-					} else {
-						Text(friendTag.displayName)
 					}
-				}
-				.foregroundColor(.white)
-				.font(.title)
-				.fontWeight(.semibold)
+					.foregroundColor(.white)
+					.font(.title)
+					.fontWeight(.semibold)
 
-				Spacer()
-				TagFriendsView(
-					friends: friendTag.friends, isExpanded: $isExpanded)
-			}
-			.padding()
-			.background(
-				RoundedRectangle(cornerRadius: universalRectangleCornerRadius)
+					Spacer()
+					TagFriendsView(
+						friends: friendTag.friends, isExpanded: $isExpanded)
+				}
+				.padding()
+				.background(
+					RoundedRectangle(
+						cornerRadius: universalRectangleCornerRadius
+					)
 					.fill(Color(hex: editedColorHexCode))
-			)
+				)
+			}
 			if isExpanded {
 				ExpandedTagView(
 					currentSelectedColorHexCode: $editedColorHexCode,
@@ -133,24 +139,7 @@ struct TagFriendsView: View {
 	@Binding var isExpanded: Bool
 
 	var body: some View {
-		HStack(spacing: -10) {
-			ForEach(friends ?? []) { friend in
-				if let pfpUrl = friend.profilePicture {
-					AsyncImage(url: URL(string: pfpUrl)) {
-						image in
-						image
-							.ProfileImageModifier(imageType: .eventParticipants)
-					} placeholder: {
-						Circle()
-							.fill(Color.gray)
-							.frame(width: 25, height: 25)
-					}
-				} else {
-					Circle()
-						.fill(.gray)
-						.frame(width: 25, height: 25)
-				}
-			}
+		ZStack {
 			Button(action: {
 				withAnimation {
 					isExpanded.toggle()  // Toggle expanded state
@@ -165,6 +154,29 @@ struct TagFriendsView: View {
 							.stroke(universalAccentColor, lineWidth: 2)
 					)
 			}
+			.offset(x: CGFloat((friends?.count ?? 0)) * 15)  // Position the button after the last profile picture
+			
+			ForEach(Array((friends ?? []).enumerated().reversed()), id: \.element.id) {
+				index, friend in
+				if let pfpUrl = friend.profilePicture {
+					AsyncImage(url: URL(string: pfpUrl)) { image in
+						image
+							.ProfileImageModifier(imageType: .eventParticipants)
+					} placeholder: {
+						Circle()
+							.fill(Color.gray)
+							.frame(width: 25, height: 25)
+					}
+					.offset(x: CGFloat(index) * 15)  // Adjust overlap spacing
+				} else {
+					Circle()
+						.fill(.gray)
+						.frame(width: 25, height: 25)
+						.offset(x: CGFloat(index) * 15)  // Adjust overlap spacing
+				}
+			}
+
 		}
+		.padding(.trailing, CGFloat((friends?.count ?? 0) * 15))
 	}
 }


### PR DESCRIPTION
- Fetching friend-tag-specific events by pressing different tags in `(Feed/Map)View.swift`
    - + API call adjustment for this, to depend on `@Published` var in `FeedViewModel.swift`
- Tags show up in feed/map views
- omit everyone tag from tags list of a friend (obvious that they're apart of your 'everyone' tag + this matches Figma)
- Improved UI of friend profile pictures in `TagRow.swift`