### PR TITLE
108 friend tag toggle UI touch ups

### DIFF
--- a/Spawn-App-iOS-SwiftUI/Views/FriendsView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FriendsView.swift
@@ -8,113 +8,91 @@
 import SwiftUI
 
 struct FriendsView: View {
-	let user: User
-	let source: BackButtonSourcePageType
+    let user: User
+    let source: BackButtonSourcePageType
+    
+    
+    @State private var selectedTab: FriendTagToggle = .friends
+    
+    // for add friend to tag popup:
+    @State private var showAddFriendToTagButtonPressedPopupView: Bool = false
+    @State private var popupOffset: CGFloat = 1000
+    @State private var selectedFriendTagId: UUID? = nil
+    
+    init(user: User, source: BackButtonSourcePageType) {
+        self.user = user
+        self.source = source
+    }
+    
+    var body: some View {
+        ZStack {
+            NavigationStack {
+                VStack(spacing: 20) {
+                    HStack {
+                        BackButton(user: user, source: source)
+                        Spacer()
+                        FriendTagToggleView(selectedTab: $selectedTab)
+                        Spacer()
+                    }
+                    .padding(.horizontal)
+                    
+                    if selectedTab == .friends {
+                        FriendsTabView(user: user)
+                    } else {
+                        TagsTabView(
+                            userId: user.id,
+                            addFriendToTagButtonPressedCallback: { friendTagId in
+                                showAddFriendToTagButtonPressedPopupView = true
+                                selectedFriendTagId = friendTagId
+                            }
+                        )
+                    }
+                    
+                }
+                .padding()
+                .background(universalBackgroundColor)
+                .navigationBarHidden(true)
+                .dimmedBackground(
+                    isActive: showAddFriendToTagButtonPressedPopupView)
+            }
+            if showAddFriendToTagButtonPressedPopupView {
+                addFriendToTagButtonPopupView
+            }
+        }
+    }
+    func closePopup() {
+        popupOffset = 1000
+        showAddFriendToTagButtonPressedPopupView = false
+    }
+    
+    var addFriendToTagButtonPopupView: some View {
+            Group {
+                if let friendTagIdForPopup = selectedFriendTagId {
+                    ZStack {
+                        Color(.black)
+                            .opacity(0.5)
+                            .onTapGesture {
+                                closePopup()
+                            }
 
-	//TODO: fix the friendtag toggle to look like figma design
-	@State private var selectedTab: FriendTagToggle = .friends 
-
-	// for add friend to tag popup:
-	@State private var showAddFriendToTagButtonPressedPopupView: Bool = false
-	@State private var popupOffset: CGFloat = 1000
-	@State private var selectedFriendTagId: UUID? = nil
-
-	init(user: User, source: BackButtonSourcePageType) {
-		self.user = user
-		self.source = source
-	}
-
-	var body: some View {
-		ZStack {
-			NavigationStack {
-				VStack(spacing: 20) {
-					header
-					if selectedTab == .friends {
-						FriendsTabView(user: user)
-					} else {
-						TagsTabView(
-							userId: user.id,
-							addFriendToTagButtonPressedCallback: {
-								friendTagId in
-								showAddFriendToTagButtonPressedPopupView = true
-								selectedFriendTagId = friendTagId
-							})
-					}
-				}
-				.padding()
-				.background(universalBackgroundColor)
-				.navigationBarHidden(true)
-				.dimmedBackground(
-					isActive: showAddFriendToTagButtonPressedPopupView)
-			}
-			if showAddFriendToTagButtonPressedPopupView {
-				addFriendToTagButtonPopupView
-			}
-		}
-	}
-	func closePopup() {
-		popupOffset = 1000
-		showAddFriendToTagButtonPressedPopupView = false
-	}
+                        AddFriendToTagView(
+                            userId: user.id, friendTagId: friendTagIdForPopup, closeCallback: closePopup
+                        )
+                        .offset(x: 0, y: popupOffset)
+                        .onAppear {
+                            popupOffset = 0
+                        }
+                        .padding(.horizontal)
+                        .padding(.vertical, 250)
+                    }
+                    .ignoresSafeArea()
+                }
+            }
+        }
 }
 
-extension FriendsView {
-	var addFriendToTagButtonPopupView: some View {
-		Group {
-			if let friendTagIdForPopup = selectedFriendTagId {
-				ZStack {
-					Color(.black)
-						.opacity(0.5)
-						.onTapGesture {
-							closePopup()
-						}
-
-					AddFriendToTagView(
-						userId: user.id, friendTagId: friendTagIdForPopup, closeCallback: closePopup
-					)
-					.offset(x: 0, y: popupOffset)
-					.onAppear {
-						popupOffset = 0
-					}
-					.padding(.horizontal)
-					.padding(.vertical, 250)
-				}
-				.ignoresSafeArea()
-			}
-		}
-	}
-
-	fileprivate var header: some View {
-		HStack {
-			BackButton(user: user, source: source)
-			Spacer()
-			Picker("", selection: $selectedTab) {
-				Text("friends")
-					.tag(FriendTagToggle.friends)
-				//TODO: change color of text to universalAccentColor when selected and universalBackgroundColor when not
-
-				Text("tags")
-					.tag(FriendTagToggle.tags)
-				//TODO: change color of text to universalAccentColor when selected and universalBackgroundColor when not
-			}
-			.pickerStyle(SegmentedPickerStyle())
-			.frame(width: 150, height: 40)
-			.background(
-				RoundedRectangle(cornerRadius: universalRectangleCornerRadius)
-					.fill(universalAccentColor)
-			)
-			.overlay(
-				RoundedRectangle(cornerRadius: universalRectangleCornerRadius)
-					.stroke(universalBackgroundColor, lineWidth: 1)
-			)
-			.cornerRadius(universalRectangleCornerRadius)
-			Spacer()
-		}
-		.padding(.horizontal)
-	}
-}
 
 @available(iOS 17.0, *)
 #Preview {
-	FriendsView(user: .danielAgapov, source: .feed)
+    FriendsView(user: .danielAgapov, source: .feed)
 }

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/Common/FriendTagToggleView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/Common/FriendTagToggleView.swift
@@ -1,0 +1,64 @@
+//
+//  FriendTagToggleView.swift
+//  Spawn-App-iOS-SwiftUI
+//
+//  Created by Raul.Reyes on 18/02/25.
+//
+
+import SwiftUI
+
+struct FriendTagToggleView: View {
+    @Binding var selectedTab: FriendTagToggle
+    @Namespace private var animationNamespace
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach([FriendTagToggle.friends, FriendTagToggle.tags], id: \.self) { tab in
+                Text(tab == .friends ? "friends" : "tags")
+                    .foregroundColor(selectedTab == tab ? universalAccentColor : .white)
+                    .frame(width: 65, height: 33)
+                    .padding(.horizontal, 10)
+                    .font(.system(size: 16, weight: .semibold))
+                    .background(
+                        ZStack {
+                            if selectedTab == tab {
+                                RoundedRectangle(cornerRadius: 22)
+                                    .fill(universalBackgroundColor)
+                                    .matchedGeometryEffect(id: "pickerSelection", in: animationNamespace)
+                                    .frame(width: 80, height: 30)
+                            }
+                        }
+                    )
+                    .onTapGesture {
+                        withAnimation(.spring(response: 0.2, dampingFraction: 0.5, blendDuration: 0.1)) {
+                            selectedTab = tab
+                        }
+                    }
+            }
+        }
+        .padding(5)
+        .clipShape(Capsule())
+
+        .padding(.horizontal)
+        .background(
+            ZStack {
+                RoundedRectangle(cornerRadius: 22)
+                    .fill(universalAccentColor)
+                    .frame(width: 180, height: 42)
+                
+                RoundedRectangle(cornerRadius: 22)
+                    .fill(Color.black.opacity(0.4))
+                    .frame(width: 165, height: 33)
+            }
+        )
+    }
+}
+
+
+@available(iOS 17.0, *)
+#Preview {
+    @State @Previewable var selectedTab: FriendTagToggle = .friends
+    
+    FriendTagToggleView(selectedTab: $selectedTab)
+        .padding()
+}

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/Common/FriendTagToggleView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/Common/FriendTagToggleView.swift
@@ -25,7 +25,7 @@ struct FriendTagToggleView: View {
                                 RoundedRectangle(cornerRadius: 22)
                                     .fill(universalBackgroundColor)
                                     .matchedGeometryEffect(id: "pickerSelection", in: animationNamespace)
-                                    .frame(width: 80, height: 30)
+                                    .frame(width: 80, height: 33)
                             }
                         }
                     )

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/EventCreationFriendsViews/InviteView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/EventCreationFriendsViews/InviteView.swift
@@ -10,8 +10,7 @@ import SwiftUI
 struct InviteView: View {
 	let user: User
 
-	//TODO: fix the friendtag toggle to look like figma design
-	@State private var selectedTab: FriendTagToggle = .friends 
+	@State private var selectedTab: FriendTagToggle = .friends
 
 	init(user: User) {
 		self.user = user
@@ -20,47 +19,20 @@ struct InviteView: View {
 	var body: some View {
 		NavigationStack {
 			VStack(spacing: 20) {
-				header
-				if selectedTab == .friends {
-					InviteFriendsView(user: user)
-				} else {
-					InviteTagsView(user: user)
-				}
+                FriendTagToggleView(selectedTab: $selectedTab)
+                
+                if selectedTab == .friends {
+                    InviteFriendsView(user: user)
+                } else {
+                    InviteTagsView(user: user)
+                }
 			}
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
 			.background(universalBackgroundColor)
 		}
 	}
 }
 
-private extension InviteView {
-	var header: some View {
-		HStack {
-			Spacer()
-			Picker("", selection: $selectedTab) {
-				Text("friends")
-					.tag(FriendTagToggle.friends)
-				//TODO: change color of text to universalAccentColor when selected and universalBackgroundColor when not
-
-				Text("tags")
-					.tag(FriendTagToggle.tags)
-				//TODO: change color of text to universalAccentColor when selected and universalBackgroundColor when not
-			}
-			.pickerStyle(SegmentedPickerStyle())
-			.frame(width: 150, height: 40)
-			.background(
-				RoundedRectangle(cornerRadius: universalRectangleCornerRadius)
-					.fill(universalAccentColor)
-			)
-			.overlay(
-				RoundedRectangle(cornerRadius: universalRectangleCornerRadius)
-					.stroke(universalBackgroundColor, lineWidth: 1)
-			)
-			.cornerRadius(universalRectangleCornerRadius)
-			Spacer()
-		}
-		.padding(.horizontal)
-	}
-}
 
 @available(iOS 17.0, *)
 #Preview


### PR DESCRIPTION
### #108 Issue
- Created `FriendTagToggleView` to make it reusable across `FriendsView` and `InviteView`.
- Reworked the friends/tag toggle to follow the Figma mockup.

Before:
![IMG_2059](https://github.com/user-attachments/assets/48e8abb4-8610-4009-a707-70cab29191ac)


After:
![IMG_50370F4A3A5C-1](https://github.com/user-attachments/assets/fab77ad9-1cd6-4e40-9415-da7e93d44d98)



