### PR TITLE
Build 71: Chat Message Sending Feature + Fixed Event Loading + Added usernames to events

### DIFF
--- a/Spawn-App-iOS-SwiftUI/Models/DTOs/CreateChatMessageDTO.swift
+++ b/Spawn-App-iOS-SwiftUI/Models/DTOs/CreateChatMessageDTO.swift
@@ -1,0 +1,25 @@
+//
+//  CreateChatMessageDTO.swift
+//  Spawn-App-iOS-SwiftUI
+//
+//  Created by Daniel Agapov on 2025-03-06.
+//
+
+import Foundation
+
+// Will correspond to `CreateChatMessageDTO` in the back-end:
+class CreateChatMessageDTO: Identifiable, Codable {
+	var content: String
+	var senderUserId: UUID
+	var eventId: UUID
+
+	init(
+		content: String, senderUserId: UUID,
+		eventId: UUID
+	) {
+		self.content = content
+		self.senderUserId = senderUserId
+		self.eventId = eventId
+	}
+}
+

--- a/Spawn-App-iOS-SwiftUI/Models/DTOs/Event/FullFeedEventDTO.swift
+++ b/Spawn-App-iOS-SwiftUI/Models/DTOs/Event/FullFeedEventDTO.swift
@@ -32,6 +32,7 @@ class FullFeedEventDTO: Identifiable, Codable {
 	var chatMessages: [FullEventChatMessageDTO]?
 	var eventFriendTagColorHexCodeForRequestingUser: String?
 	var participationStatus: ParticipationStatus?
+	var isSelfOwned: Bool?
 
 	init(
 		id: UUID,
@@ -45,7 +46,8 @@ class FullFeedEventDTO: Identifiable, Codable {
 		invitedUsers: [BaseUserDTO]? = nil,
 		chatMessages: [FullEventChatMessageDTO]? = nil,
 		eventFriendTagColorHexCodeForRequestingUser: String? = nil,
-		participationStatus: ParticipationStatus? = nil
+		participationStatus: ParticipationStatus? = nil,
+		isSelfOwned: Bool? = nil
 	) {
 		self.id = id
 		self.title = title
@@ -60,6 +62,7 @@ class FullFeedEventDTO: Identifiable, Codable {
 		self.eventFriendTagColorHexCodeForRequestingUser =
 		eventFriendTagColorHexCodeForRequestingUser
 		self.participationStatus = participationStatus
+		self.isSelfOwned = isSelfOwned
 	}
 }
 

--- a/Spawn-App-iOS-SwiftUI/Models/DTOs/Event/FullFeedEventDTO.swift
+++ b/Spawn-App-iOS-SwiftUI/Models/DTOs/Event/FullFeedEventDTO.swift
@@ -9,7 +9,11 @@
 
 import Foundation
 
-class FullFeedEventDTO: Identifiable, Codable {
+class FullFeedEventDTO: Identifiable, Codable, Equatable {
+	static func == (lhs: FullFeedEventDTO, rhs: FullFeedEventDTO) -> Bool {
+		return lhs.id == rhs.id
+	}
+
 	var id: UUID
 	var title: String?
 

--- a/Spawn-App-iOS-SwiftUI/Models/DTOs/FullEventChatMessageDTO.swift
+++ b/Spawn-App-iOS-SwiftUI/Models/DTOs/FullEventChatMessageDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class FullEventChatMessageDTO: Identifiable, Codable {
+class FullEventChatMessageDTO: Identifiable, Codable, Equatable {
 	var id: UUID
 	var content: String
 	var timestamp: Date
@@ -18,6 +18,10 @@ class FullEventChatMessageDTO: Identifiable, Codable {
 	var likedByUsers: [BaseUserDTO]?
 	// tech note: in user's view of event, check if that user is in
 	// the `ChatMessage`'s `likedBy` array (`[User]`)
+	
+	static func == (lhs: FullEventChatMessageDTO, rhs: FullEventChatMessageDTO) -> Bool {
+		return lhs.id == rhs.id
+	}
 
 	init(
 		id: UUID, content: String, timestamp: Date, senderUser: BaseUserDTO,

--- a/Spawn-App-iOS-SwiftUI/Services/API/APIService.swift
+++ b/Spawn-App-iOS-SwiftUI/Services/API/APIService.swift
@@ -390,11 +390,6 @@ class APIService: IAPIService {
 			let jsonData = try JSONSerialization.data(
 				withJSONObject: userCreationDTO)
 			request.httpBody = jsonData
-			
-			// Debug: Print the request body for troubleshooting
-			if let jsonString = String(data: jsonData, encoding: .utf8) {
-				print("Request body: \(jsonString)")
-			}
 		} catch {
 			print("Error encoding request body: \(error)")
 			throw APIError.failedJSONParsing(url: finalURL)

--- a/Spawn-App-iOS-SwiftUI/Services/API/MockAPIService.swift
+++ b/Spawn-App-iOS-SwiftUI/Services/API/MockAPIService.swift
@@ -139,7 +139,8 @@ class MockAPIService: IAPIService {
 			return FullFriendTagDTO.close as! U?
 		}
 
-		return
+		
+		throw APIError.invalidData
 	}
 
 	func updateData<T: Encodable, U: Decodable>(

--- a/Spawn-App-iOS-SwiftUI/Services/API/MockAPIService.swift
+++ b/Spawn-App-iOS-SwiftUI/Services/API/MockAPIService.swift
@@ -139,8 +139,7 @@ class MockAPIService: IAPIService {
 			return FullFriendTagDTO.close as! U?
 		}
 
-		// this means I need to include the url call in this mock `sendData` method:
-		throw APIError.invalidData
+		return
 	}
 
 	func updateData<T: Encodable, U: Decodable>(

--- a/Spawn-App-iOS-SwiftUI/ViewModels/Event/EventCreationViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/Event/EventCreationViewModel.swift
@@ -19,6 +19,14 @@ class EventCreationViewModel: ObservableObject {
 	@Published var selectedFriends: [FullFriendUserDTO] = []
 
 	private var apiService: IAPIService
+	
+	// Reference to the FeedViewModel for refreshing events
+	private var feedViewModel: FeedViewModel?
+	
+	// Set the FeedViewModel reference
+	func setFeedViewModel(_ viewModel: FeedViewModel) {
+		self.feedViewModel = viewModel
+	}
 
 	public static func reInitialize() {
 		shared = EventCreationViewModel()
@@ -63,6 +71,12 @@ class EventCreationViewModel: ObservableObject {
 			do {
 				_ = try await self.apiService.sendData(
 					event, to: url, parameters: nil)
+				
+				// Refresh events in the FeedViewModel if available
+				if let feedViewModel = self.feedViewModel {
+					await feedViewModel.fetchEventsForUser()
+					print("Event created successfully, refreshing events")
+				}
 			} catch {
 				await MainActor.run {
 					creationMessage =

--- a/Spawn-App-iOS-SwiftUI/ViewModels/Event/EventDescriptionViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/Event/EventDescriptionViewModel.swift
@@ -63,11 +63,32 @@ class EventDescriptionViewModel: ObservableObject {
 			do {
 				_ = try await self.apiService.sendData(
 					chatMessage, to: url, parameters: nil)
+				
+				// After successfully sending the message, fetch the updated event data
+				await fetchUpdatedEventData()
 			} catch {
 				await MainActor.run {
 					creationMessage =
 					"There was an error sending your chat message. Please try again"
 				}
+			}
+		}
+	}
+
+	// Add a new method to fetch updated event data
+	private func fetchUpdatedEventData() async {
+		// Construct URL for fetching the updated event
+		if let url = URL(string: APIService.baseURL + "events/\(event.id)") {
+			do {
+				let updatedEvent: FullFeedEventDTO = try await self.apiService.fetchData(
+					from: url, parameters: nil)
+				
+				// Update the event on the main thread
+				await MainActor.run {
+					self.event = updatedEvent
+				}
+			} catch {
+				print("Error fetching updated event data: \(error)")
 			}
 		}
 	}

--- a/Spawn-App-iOS-SwiftUI/ViewModels/Event/EventDescriptionViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/Event/EventDescriptionViewModel.swift
@@ -10,9 +10,33 @@ import Foundation
 class EventDescriptionViewModel: ObservableObject {
 	@Published var users: [BaseUserDTO]?
 	var event: FullFeedEventDTO
+	var senderUserId: UUID
+	var apiService: IAPIService
+	var creationMessage: String?
 
-	init(event: FullFeedEventDTO, users: [BaseUserDTO]? = []) {
+	init(apiService: IAPIService, event: FullFeedEventDTO, users: [BaseUserDTO]? = [], senderUserId: UUID) {
+		self.apiService = apiService
 		self.event = event
 		self.users = users
+		self.senderUserId = senderUserId
+	}
+
+	func sendMessage(message: String) async {
+		let chatMessage: CreateChatMessageDTO = CreateChatMessageDTO(
+			content: message,
+			senderUserId: senderUserId,
+			eventId: event.id
+		)
+		if let url = URL(string: APIService.baseURL + "chatMessages") {
+			do {
+				_ = try await self.apiService.sendData(
+					chatMessage, to: url, parameters: nil)
+			} catch {
+				await MainActor.run {
+					creationMessage =
+					"There was an error sending your chat message. Please try again"
+				}
+			}
+		}
 	}
 }

--- a/Spawn-App-iOS-SwiftUI/ViewModels/UserAuthViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/UserAuthViewModel.swift
@@ -61,8 +61,9 @@ class UserAuthViewModel: NSObject, ObservableObject {
 		super.init()  // Call super.init() before using `self`
 
 		check()
-		Task {
-			await spawnFetchUserIfAlreadyExists()
+		Task { [weak self] in
+			guard let self = self else { return }
+			await self.spawnFetchUserIfAlreadyExists()
 		}
 	}
 
@@ -135,7 +136,8 @@ class UserAuthViewModel: NSObject, ObservableObject {
 				self.externalUserId = userIdentifier
 
 				// Check user existence AFTER setting credentials
-				Task {
+				Task { [weak self] in
+					guard let self = self else { return }
 					await self.spawnFetchUserIfAlreadyExists()
 				}
 			}
@@ -144,7 +146,8 @@ class UserAuthViewModel: NSObject, ObservableObject {
 				"Apple Sign-In failed: \(error.localizedDescription)"
 			print(self.errorMessage as Any)
 			// Check user existence AFTER setting credentials
-			Task {
+			Task { [weak self] in
+				guard let self = self else { return }
 				await self.spawnFetchUserIfAlreadyExists()
 			}
 		}
@@ -171,7 +174,8 @@ class UserAuthViewModel: NSObject, ObservableObject {
 
 			GIDSignIn.sharedInstance.signIn(
 				withPresenting: presentingViewController
-			) { signInResult, error in
+			) { [weak self] signInResult, error in
+				guard let self = self else { return }
 				if let error = error {
 					print(error.localizedDescription)
 					return
@@ -189,7 +193,8 @@ class UserAuthViewModel: NSObject, ObservableObject {
 				self.externalUserId = user.userID
 				self.authProvider = .google
 
-				Task {
+				Task { [weak self] in
+					guard let self = self else { return }
 					await self.spawnFetchUserIfAlreadyExists()
 				}
 			}

--- a/Spawn-App-iOS-SwiftUI/ViewModels/UserAuthViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/UserAuthViewModel.swift
@@ -56,14 +56,24 @@ class UserAuthViewModel: NSObject, ObservableObject {
 		{
 			self.externalUserId = externalUserId
 			self.isLoggedIn = true
+			print("Retrieved externalUserId from Keychain: \(externalUserId)")
 		}
 
 		super.init()  // Call super.init() before using `self`
 
-		check()
+		// Only attempt to restore Google sign-in state if we have an externalUserId
+		if self.externalUserId != nil {
+			check()
+		}
+		
+		// Try to fetch user data using stored externalUserId
 		Task { [weak self] in
 			guard let self = self else { return }
-			await self.spawnFetchUserIfAlreadyExists()
+			
+			if self.externalUserId != nil {
+				print("Attempting to fetch user with stored externalUserId")
+				await self.spawnFetchUserIfAlreadyExists()
+			}
 		}
 	}
 
@@ -182,9 +192,11 @@ class UserAuthViewModel: NSObject, ObservableObject {
 				}
 
 				guard let user = signInResult?.user else { return }
+				// Request a higher resolution image (400px instead of 100px)
 				self.profilePicUrl =
-					user.profile?.imageURL(withDimension: 100)?.absoluteString
+					user.profile?.imageURL(withDimension: 400)?.absoluteString
 					?? ""
+				print("Google profile picture URL: \(self.profilePicUrl ?? "none")")
 				self.fullName = user.profile?.name
 				self.givenName = user.profile?.givenName
 				self.familyName = user.profile?.familyName
@@ -264,15 +276,21 @@ class UserAuthViewModel: NSObject, ObservableObject {
 			}
 			return
 		}
-
-		guard let unwrappedEmail = self.email else {
+		
+		// For Apple Sign In, if email is nil, we should direct to UserInfoInputView
+		if self.authProvider == .apple && self.email == nil {
 			await MainActor.run {
-				self.errorMessage = "Email is missing or invalid."
-				print(self.errorMessage as Any)
+				self.spawnUser = nil
 				self.shouldNavigateToUserInfoInputView = true
+				self.hasCheckedSpawnUserExistence = true
 			}
 			return
 		}
+
+		// Only proceed with API call if we have email or it's not Apple auth
+		let emailToUse = self.email ?? ""
+		
+		print("Fetching user with externalUserId: \(unwrappedExternalUserId), email: \(emailToUse)")
 
 		if let url = URL(string: APIService.baseURL + "auth/sign-in") {
 			do {
@@ -281,13 +299,16 @@ class UserAuthViewModel: NSObject, ObservableObject {
 						from: url,
 						parameters: [
 							"externalUserId": unwrappedExternalUserId,
-							"email": unwrappedEmail,
+							"email": emailToUse,
 						]
 					)
 
 				await MainActor.run {
+					print("Successfully fetched user: \(fetchedSpawnUser.username)")
 					self.spawnUser = fetchedSpawnUser
 					self.shouldNavigateToUserInfoInputView = false  // User exists, no need to navigate to UserInfoInputView
+					self.isFormValid = true  // Auto-validate the form since we have a valid user
+					self.setShouldNavigateToFeedView() // Check if we should navigate to feed
 				}
 			} catch {
 				await MainActor.run {
@@ -328,6 +349,13 @@ class UserAuthViewModel: NSObject, ObservableObject {
 		if let authProvider = self.authProvider {
 			parameters["provider"] = authProvider.rawValue
 		}
+		
+		// If we have a profile picture URL from the provider (Google/Apple) and no selected image,
+		// include it in the parameters so it can be used
+		if profilePicture == nil, let profilePicUrl = self.profilePicUrl, !profilePicUrl.isEmpty {
+			parameters["profilePicUrl"] = profilePicUrl
+			print("Including provider profile picture URL in parameters: \(profilePicUrl)")
+		}
 
 		do {
 			// Use the new createUser method
@@ -351,10 +379,17 @@ class UserAuthViewModel: NSObject, ObservableObject {
 					key: "externalUserId", data: data)
 				if !success {
 					print("Failed to save externalUserId to Keychain")
+				} else {
+					print("Successfully saved externalUserId to Keychain: \(externalUserId)")
 				}
 			}
 
-			print("User created successfully")
+			print("User created successfully: \(fetchedUser.username)")
+			if let profilePic = fetchedUser.profilePicture {
+				print("Profile picture set: \(profilePic)")
+			} else {
+				print("No profile picture set in created user")
+			}
 
 		} catch {
 			print("Error creating the user: \(error)")

--- a/Spawn-App-iOS-SwiftUI/Views/Authentication/UserInfoInputView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/Authentication/UserInfoInputView.swift
@@ -55,18 +55,6 @@ struct UserInfoInputView: View {
 	var body: some View {
 		NavigationStack {
 			VStack(spacing: 16) {
-				if let unwrappedSpawnUser = userAuth.spawnUser {
-					NavigationLink(
-						destination: FeedView(user: unwrappedSpawnUser)
-							.navigationBarTitle("")
-							.navigationBarHidden(true),
-						isActive: $userAuth.shouldNavigateToFeedView
-					) {
-						EmptyView()
-					}
-					.hidden()
-				}
-
 				Spacer()
 				Spacer()
 
@@ -166,6 +154,13 @@ struct UserInfoInputView: View {
 				Spacer()
 				Spacer()
 				Spacer()
+			}
+			.navigationDestination(isPresented: $userAuth.shouldNavigateToFeedView) {
+				if let unwrappedSpawnUser = userAuth.spawnUser {
+					FeedView(user: unwrappedSpawnUser)
+						.navigationBarTitle("")
+						.navigationBarHidden(true)
+				}
 			}
 			.onAppear {
 				userAuth.objectWillChange.send()  // Trigger initial UI update

--- a/Spawn-App-iOS-SwiftUI/Views/Authentication/UserInfoInputView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/Authentication/UserInfoInputView.swift
@@ -127,9 +127,13 @@ struct UserInfoInputView: View {
 					validateFields()
 					if isFirstNameValid && isUsernameValid && (!needsEmail || isEmailValid) {
 						Task {
+							// If no image is selected but we have a profile picture URL from Google/Apple,
+							// we'll pass nil for profilePicture and let the backend use the URL
+							print("Profile picture URL from provider: \(userAuth.profilePicUrl ?? "none")")
+							
 							await userAuth.spawnMakeUser(
 								username: username,
-								profilePicture: selectedImage, // Pass the selected image
+								profilePicture: selectedImage, // Pass the selected image or nil
 								firstName: userAuth.givenName ?? "",
 								lastName: userAuth.familyName ?? "",
 								email: userAuth.authProvider == .apple ? email : userAuth.email ?? ""

--- a/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
@@ -77,10 +77,13 @@ struct EventCardView: View {
 
 extension EventCardView {
 	var usernamesView: some View {
-		Text(
-			"@\(event.creatorUser.username) + \((event.participantUsers?.count ?? 0) + (event.invitedUsers?.count ?? 0)) more"
-		)
-					.foregroundColor(.white)
+		let participantCount = (event.participantUsers?.count ?? 0) - 1 // Subtract 1 to exclude creator
+		let invitedCount = event.invitedUsers?.count ?? 0
+		let totalCount = participantCount + invitedCount
+		
+		return Text("@\(event.creatorUser.username)\(totalCount > 0 ? " + \(totalCount) more" : "")")
+			.foregroundColor(.white)
+			.font(.caption)
 	}
 }
 

--- a/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
@@ -44,9 +44,12 @@ struct EventCardView: View {
 							}
 							Spacer()
 							HStack {
-								EventInfoView(
-									event: event, eventInfoType: .location)
-								Spacer()
+								// Only show location if it exists
+								if event.location?.name != nil && !(event.location?.name?.isEmpty ?? true) {
+									EventInfoView(
+										event: event, eventInfoType: .location)
+									Spacer()
+								}
 							}
 						}
 						.foregroundColor(.white)
@@ -93,7 +96,7 @@ struct EventCardView: View {
 								.frame(width: 15)
 						}
 						.frame(maxHeight: .infinity)
-						.padding(.trailing, 8)
+						.padding(.horizontal, 8)
 					}
 				}
 			}

--- a/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
@@ -81,7 +81,11 @@ extension EventCardView {
 		let invitedCount = event.invitedUsers?.count ?? 0
 		let totalCount = participantCount + invitedCount
 		
-		return Text("@\(event.creatorUser.username)\(totalCount > 0 ? " + \(totalCount) more" : "")")
+		let displayText = (event.isSelfOwned == true) 
+			? "You\(totalCount > 0 ? " + \(totalCount) more" : "")"
+			: "@\(event.creatorUser.username)\(totalCount > 0 ? " + \(totalCount) more" : "")"
+		
+		return Text(displayText)
 			.foregroundColor(.white)
 			.font(.caption)
 	}

--- a/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
@@ -29,6 +29,8 @@ struct EventCardView: View {
 		NavigationStack {
 			VStack {
 				EventCardTopRowView(event: event)
+				Text("@\(event.creatorUser) + \(event.participantUsers.count + event.invitedUsers.count) more")
+					.foregroundColor(.white)
 				Spacer()
 				HStack {
 					VStack {

--- a/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
@@ -85,14 +85,15 @@ struct EventCardView: View {
 						VStack {
 							Text("CREATED BY YOU")
 								.font(.caption2)
-								.fontWeight(.semibold)
+								.fontWeight(.medium)
 								.foregroundColor(.white)
-								.rotationEffect(.degrees(90))
+								.opacity(0.7)
+								.rotationEffect(.degrees(-90))
 								.fixedSize()
-								.frame(width: 20)
+								.frame(width: 15)
 						}
 						.frame(maxHeight: .infinity)
-						.padding(.trailing, 5)
+						.padding(.trailing, 8)
 					}
 				}
 			}

--- a/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
@@ -29,8 +29,10 @@ struct EventCardView: View {
 		NavigationStack {
 			VStack {
 				EventCardTopRowView(event: event)
-				Text("@\(event.creatorUser) + \(event.participantUsers.count + event.invitedUsers.count) more")
-					.foregroundColor(.white)
+				HStack{
+					usernamesView
+					Spacer()
+				}
 				Spacer()
 				HStack {
 					VStack {
@@ -73,11 +75,20 @@ struct EventCardView: View {
 	}
 }
 
+extension EventCardView {
+	var usernamesView: some View {
+		Text(
+			"@\(event.creatorUser.username) + \((event.participantUsers?.count ?? 0) + (event.invitedUsers?.count ?? 0)) more"
+		)
+					.foregroundColor(.white)
+	}
+}
+
 #Preview {
 	EventCardView(
 		userId: UUID(),
 		event: FullFeedEventDTO.mockDinnerEvent,
-		color: universalAccentColor,
+		color: universalSecondaryColor,
 		callback: {_, _ in}
 	)
 }

--- a/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
@@ -27,44 +27,75 @@ struct EventCardView: View {
 	}
 	var body: some View {
 		NavigationStack {
-			VStack {
-				EventCardTopRowView(event: event)
-				HStack{
-					usernamesView
-					Spacer()
-				}
-				Spacer()
-				HStack {
-					VStack {
-						HStack {
-							EventInfoView(event: event, eventInfoType: .time)
-							Spacer()
-						}
+			ZStack {
+				// Main card content
+				VStack {
+					EventCardTopRowView(event: event)
+					HStack{
+						usernamesView
 						Spacer()
-						HStack {
-							EventInfoView(
-								event: event, eventInfoType: .location)
-							Spacer()
-						}
 					}
-					.foregroundColor(.white)
 					Spacer()
-						.frame(width: 30)
-					Circle()
-						.CircularButton(
-							systemName: viewModel.isParticipating
-								? "checkmark" : "star.fill",
-							buttonActionCallback: {
-								Task {
-									await viewModel.toggleParticipation()
-								}
-							})
+					HStack {
+						VStack {
+							HStack {
+								EventInfoView(event: event, eventInfoType: .time)
+								Spacer()
+							}
+							Spacer()
+							HStack {
+								EventInfoView(
+									event: event, eventInfoType: .location)
+								Spacer()
+							}
+						}
+						.foregroundColor(.white)
+						Spacer()
+							.frame(width: 30)
+						Circle()
+							.CircularButton(
+								systemName: event.isSelfOwned == true 
+									? "pencil" // Edit icon for self-owned events
+									: (viewModel.isParticipating ? "checkmark" : "star.fill"),
+								buttonActionCallback: {
+									Task {
+										if event.isSelfOwned == true {
+											// Handle edit action
+											print("Edit event")
+											// TODO: Implement edit functionality
+										} else {
+											// Toggle participation for non-owned events
+											await viewModel.toggleParticipation()
+										}
+									}
+								})
+					}
+					.frame(alignment: .trailing)
 				}
-				.frame(alignment: .trailing)
+				.padding(20)
+				.background(color)
+				.cornerRadius(universalRectangleCornerRadius)
+				
+				// "CREATED BY YOU" vertical text on the right side (only if self-owned)
+				if event.isSelfOwned == true {
+					HStack {
+						Spacer()
+						
+						// Vertical text container
+						VStack {
+							Text("CREATED BY YOU")
+								.font(.caption2)
+								.fontWeight(.semibold)
+								.foregroundColor(.white)
+								.rotationEffect(.degrees(90))
+								.fixedSize()
+								.frame(width: 20)
+						}
+						.frame(maxHeight: .infinity)
+						.padding(.trailing, 5)
+					}
+				}
 			}
-			.padding(20)
-			.background(color)
-			.cornerRadius(universalRectangleCornerRadius)
 			.onAppear {
 				viewModel.fetchIsParticipating()
 			}
@@ -86,7 +117,7 @@ extension EventCardView {
 			: "@\(event.creatorUser.username)\(totalCount > 0 ? " + \(totalCount) more" : "")"
 		
 		return Text(displayText)
-			.foregroundColor(.white)
+			.foregroundColor(Color(.systemGray4))
 			.font(.caption)
 	}
 }

--- a/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventCardView.swift
@@ -45,7 +45,7 @@ struct EventCardView: View {
 							Spacer()
 							HStack {
 								// Only show location if it exists
-								if event.location?.name != nil && !(event.location?.name?.isEmpty ?? true) {
+								if event.location?.name != nil && !(event.location?.name.isEmpty ?? true) {
 									EventInfoView(
 										event: event, eventInfoType: .location)
 									Spacer()
@@ -98,6 +98,7 @@ struct EventCardView: View {
 						.frame(maxHeight: .infinity)
 						.padding(.horizontal, 8)
 					}
+					.background(.clear)
 				}
 			}
 			.onAppear {

--- a/Spawn-App-iOS-SwiftUI/Views/EventCreationView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventCreationView.swift
@@ -425,6 +425,10 @@ extension EventCreationView {
 }
 
 #Preview {
-	EventCreationView(creatingUser: .danielAgapov, closeCallback: {})
+	EventCreationView(
+		creatingUser: .danielAgapov,
+		feedViewModel: FeedViewModel(apiService: MockAPIService(userId: UUID()), userId: UUID()),
+		closeCallback: {
+		})
 }
 

--- a/Spawn-App-iOS-SwiftUI/Views/EventCreationView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventCreationView.swift
@@ -16,9 +16,12 @@ struct EventCreationView: View {
 	var creatingUser: BaseUserDTO
 	var closeCallback: () -> Void
 
-	init(creatingUser: BaseUserDTO, closeCallback: @escaping () -> Void) {
+	init(creatingUser: BaseUserDTO, feedViewModel: FeedViewModel, closeCallback: @escaping () -> Void) {
 		self.creatingUser = creatingUser
 		self.closeCallback = closeCallback
+		
+		// Set the FeedViewModel reference
+		viewModel.setFeedViewModel(feedViewModel)
 	}
 
 	var body: some View {

--- a/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
@@ -31,6 +31,12 @@ struct EventDescriptionView: View {
 			VStack(alignment: .leading, spacing: 20) {
 				// Title and Time Information
 				EventCardTopRowView(event: viewModel.event)
+				
+				// Username display
+				HStack {
+					usernamesView
+					Spacer()
+				}
 
 				VStack {
 					HStack {
@@ -80,6 +86,16 @@ struct EventDescriptionView: View {
 			.cornerRadius(universalRectangleCornerRadius)
 		}
 		.scrollDisabled(true)  // to get fitting from `ScrollView`, without the actual scrolling, since that's only need for the `chatMessagesView`
+	}
+	
+	var usernamesView: some View {
+		let participantCount = (viewModel.event.participantUsers?.count ?? 0) - 1 // Subtract 1 to exclude creator
+		let invitedCount = viewModel.event.invitedUsers?.count ?? 0
+		let totalCount = participantCount + invitedCount
+		
+		return Text("@\(viewModel.event.creatorUser.username)\(totalCount > 0 ? " + \(totalCount) more" : "")")
+			.foregroundColor(.white)
+			.font(.caption)
 	}
 }
 

--- a/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
@@ -28,62 +28,106 @@ struct EventDescriptionView: View {
 
 	var body: some View {
 		ScrollView {
-			VStack(alignment: .leading, spacing: 20) {
-				// Title and Time Information
-				EventCardTopRowView(event: viewModel.event)
-				
-				// Username display
-				HStack {
-					usernamesView
-					Spacer()
-				}
-
-				VStack {
+			ZStack {
+				// Main content
+				VStack(alignment: .leading, spacing: 20) {
+					// Title and Time Information
+					EventCardTopRowView(event: viewModel.event)
+					
+					// Username display
 					HStack {
-						// Note
-						if let note = viewModel.event.note {
-							Text("\(note)")
-								.font(.body)
-								.padding(.bottom, 15)
-								.foregroundColor(.white)
-								.font(.body)
-								.italic()
+						usernamesView
+						Spacer()
+					}
+
+					VStack {
+						HStack {
+							// Note
+							if let note = viewModel.event.note {
+								Text("\(note)")
+									.font(.body)
+									.padding(.bottom, 15)
+									.foregroundColor(.white)
+									.font(.body)
+									.italic()
+							}
 						}
-					}
-					.frame(maxWidth: .infinity, alignment: .leading)
+						.frame(maxWidth: .infinity, alignment: .leading)
 
-					HStack(spacing: 10) {
-						EventInfoView(
-							event: viewModel.event, eventInfoType: .time)
-						EventInfoView(
-							event: viewModel.event, eventInfoType: .location)
+						HStack(spacing: 10) {
+							EventInfoView(
+								event: viewModel.event, eventInfoType: .time)
+							EventInfoView(
+								event: viewModel.event, eventInfoType: .location)
+							
+							Spacer()
+							
+							// Add participation toggle or edit button
+							Circle()
+								.CircularButton(
+									systemName: viewModel.event.isSelfOwned == true 
+										? "pencil" // Edit icon for self-owned events
+										: (viewModel.isParticipating ? "checkmark" : "star.fill"),
+									buttonActionCallback: {
+										Task {
+											if viewModel.event.isSelfOwned == true {
+												// Handle edit action
+												print("Edit event")
+												// TODO: Implement edit functionality
+											} else {
+												// Toggle participation for non-owned events
+												await viewModel.toggleParticipation()
+											}
+										}
+									})
+						}
+						.foregroundColor(.white)
 					}
-					.foregroundColor(.white)
+					.frame(maxWidth: .infinity)  // Ensures the HStack uses the full width of its parent
+
+					if let chatMessages = viewModel.event.chatMessages {
+						Divider()
+							.frame(height: 0.5)
+							.background(Color.black)
+							.opacity(1)
+						HStack {
+							Spacer()
+							Text(
+								"\(chatMessages.count) \(chatMessages.count == 1 ? "reply" : "replies")"
+							)
+							.foregroundColor(.black)
+							.opacity(0.7)
+							.font(.caption)
+						}
+						.frame(maxWidth: .infinity)
+					}
+
+					chatMessagesView
 				}
-				.frame(maxWidth: .infinity)  // Ensures the HStack uses the full width of its parent
-
-				if let chatMessages = viewModel.event.chatMessages {
-					Divider()
-						.frame(height: 0.5)
-						.background(Color.black)
-						.opacity(1)
+				.padding(20)
+				.background(color)
+				.cornerRadius(universalRectangleCornerRadius)
+				
+				// "CREATED BY YOU" vertical text on the right side (only if self-owned)
+				if viewModel.event.isSelfOwned == true {
 					HStack {
 						Spacer()
-						Text(
-							"\(chatMessages.count) \(chatMessages.count == 1 ? "reply" : "replies")"
-						)
-						.foregroundColor(.black)
-						.opacity(0.7)
-						.font(.caption)
+						
+						// Vertical text container
+						VStack {
+							Text("CREATED BY YOU")
+								.font(.caption2)
+								.fontWeight(.semibold)
+								.foregroundColor(.white)
+								.rotationEffect(.degrees(90))
+								.fixedSize()
+								.frame(width: 20)
+						}
+						.frame(maxHeight: .infinity)
+						.padding(.trailing, 5)
 					}
-					.frame(maxWidth: .infinity)
 				}
-
-				chatMessagesView
 			}
-			.padding(20)
-			.background(color)
-			.cornerRadius(universalRectangleCornerRadius)
 		}
 		.scrollDisabled(true)  // to get fitting from `ScrollView`, without the actual scrolling, since that's only need for the `chatMessagesView`
 	}
@@ -195,7 +239,7 @@ extension EventDescriptionView {
 				.background(Color.white)
 				.cornerRadius(10)
 				.font(.caption)
-				.foregroundColor(self.color)
+				.foregroundColor(universalAccentColor)
 
 			Button(action: {
 				Task {
@@ -210,6 +254,7 @@ extension EventDescriptionView {
 		}
 		.background(Color.white)
 		.cornerRadius(15)
+		.padding(.bottom, 32)
 	}
 }
 

--- a/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
@@ -117,14 +117,15 @@ struct EventDescriptionView: View {
 						VStack {
 							Text("CREATED BY YOU")
 								.font(.caption2)
-								.fontWeight(.semibold)
+								.fontWeight(.medium)
 								.foregroundColor(.white)
-								.rotationEffect(.degrees(90))
+								.opacity(0.7)
+								.rotationEffect(.degrees(-90))
 								.fixedSize()
-								.frame(width: 20)
+								.frame(width: 15)
 						}
 						.frame(maxHeight: .infinity)
-						.padding(.trailing, 5)
+						.padding(.trailing, 8)
 					}
 				}
 			}

--- a/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
@@ -57,8 +57,12 @@ struct EventDescriptionView: View {
 						HStack(spacing: 10) {
 							EventInfoView(
 								event: viewModel.event, eventInfoType: .time)
-							EventInfoView(
-								event: viewModel.event, eventInfoType: .location)
+							
+							// Only show location if it exists
+							if viewModel.event.location?.name != nil && !(viewModel.event.location?.name?.isEmpty ?? true) {
+								EventInfoView(
+									event: viewModel.event, eventInfoType: .location)
+							}
 							
 							Spacer()
 							
@@ -107,27 +111,6 @@ struct EventDescriptionView: View {
 				.padding(20)
 				.background(color)
 				.cornerRadius(universalRectangleCornerRadius)
-				
-				// "CREATED BY YOU" vertical text on the right side (only if self-owned)
-				if viewModel.event.isSelfOwned == true {
-					HStack {
-						Spacer()
-						
-						// Vertical text container
-						VStack {
-							Text("CREATED BY YOU")
-								.font(.caption2)
-								.fontWeight(.medium)
-								.foregroundColor(.white)
-								.opacity(0.7)
-								.rotationEffect(.degrees(-90))
-								.fixedSize()
-								.frame(width: 15)
-						}
-						.frame(maxHeight: .infinity)
-						.padding(.trailing, 8)
-					}
-				}
 			}
 		}
 		.scrollDisabled(true)  // to get fitting from `ScrollView`, without the actual scrolling, since that's only need for the `chatMessagesView`

--- a/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
@@ -59,7 +59,7 @@ struct EventDescriptionView: View {
 								event: viewModel.event, eventInfoType: .time)
 							
 							// Only show location if it exists
-							if viewModel.event.location?.name != nil && !(viewModel.event.location?.name?.isEmpty ?? true) {
+							if viewModel.event.location?.name != nil && !(viewModel.event.location?.name.isEmpty ?? true) {
 								EventInfoView(
 									event: viewModel.event, eventInfoType: .location)
 							}
@@ -144,6 +144,7 @@ extension EventDescriptionView {
 
 			chatBar
 				.padding(.horizontal, 25)
+				.padding(.vertical)
 		}
 		.padding(.top, 10)
 		.padding(.bottom, 10)
@@ -237,8 +238,7 @@ extension EventDescriptionView {
 			}
 		}
 		.background(Color.white)
-		.cornerRadius(15)
-		.padding(.bottom, 32)
+		.cornerRadius(universalRectangleCornerRadius)
 	}
 }
 

--- a/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
@@ -93,7 +93,11 @@ struct EventDescriptionView: View {
 		let invitedCount = viewModel.event.invitedUsers?.count ?? 0
 		let totalCount = participantCount + invitedCount
 		
-		return Text("@\(viewModel.event.creatorUser.username)\(totalCount > 0 ? " + \(totalCount) more" : "")")
+		let displayText = (viewModel.event.isSelfOwned == true) 
+			? "You\(totalCount > 0 ? " + \(totalCount) more" : "")"
+			: "@\(viewModel.event.creatorUser.username)\(totalCount > 0 ? " + \(totalCount) more" : "")"
+		
+		return Text(displayText)
 			.foregroundColor(.white)
 			.font(.caption)
 	}

--- a/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
@@ -144,7 +144,7 @@ extension FeedView {
 				}
 				.ignoresSafeArea()
 
-			EventCreationView(creatingUser: user, closeCallback: closeCreation)
+			EventCreationView(creatingUser: user, feedViewModel: viewModel, closeCallback: closeCreation)
 				.offset(x: 0, y: creationOffset)
 				.onAppear {
 					creationOffset = 0

--- a/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
@@ -118,17 +118,18 @@ extension FeedView {
 					.onAppear {
 						descriptionOffset = 0
 					}
+					.cornerRadius(universalRectangleCornerRadius)
 					.padding(.horizontal)
-					// brute-force algorithm I wrote
 					.padding(
 						.vertical,
 						max(
-							330,
-							330
-								- CGFloat(
-									100 * (event.chatMessages?.count ?? 0))
-								- CGFloat(event.note != nil ? 200 : 0))
+							250,
+							250
+							- CGFloat((event.chatMessages?.count ?? 0) > 2 ? 100 : 0)
+							- CGFloat(event.note != nil ? 50 : 0)
+						)
 					)
+
 				}
 				.ignoresSafeArea()
 			}

--- a/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
@@ -111,7 +111,8 @@ extension FeedView {
 					EventDescriptionView(
 						event: event,
 						users: event.participantUsers,
-						color: color
+						color: color,
+						userId: user.id
 					)
 					.offset(x: 0, y: descriptionOffset)
 					.onAppear {

--- a/Spawn-App-iOS-SwiftUI/Views/MapView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/MapView.swift
@@ -77,6 +77,9 @@ struct MapView: View {
 					await viewModel.fetchEventsForUser()
 				}
 			}
+			.onChange(of: viewModel.events) { _ in
+				adjustRegionForEvents()
+			}
 			if showingEventDescriptionPopup {
 				eventDescriptionPopupView
 			}
@@ -235,7 +238,7 @@ extension MapView {
 				}
 				.ignoresSafeArea()
 
-			EventCreationView(creatingUser: user, closeCallback: closeCreation)
+			EventCreationView(creatingUser: user, feedViewModel: viewModel, closeCallback: closeCreation)
 				.offset(x: 0, y: creationOffset)
 				.onAppear {
 					creationOffset = 0

--- a/Spawn-App-iOS-SwiftUI/Views/MapView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/MapView.swift
@@ -202,7 +202,8 @@ extension MapView {
 					EventDescriptionView(
 						event: event,
 						users: event.participantUsers,
-						color: color
+						color: color,
+						userId: user.id
 					)
 					.offset(x: 0, y: descriptionOffset)
 					.onAppear {

--- a/Spawn-App-iOS-SwiftUI/Views/ProfileView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/ProfileView.swift
@@ -49,7 +49,7 @@ struct ProfileView: View {
 
 					Circle()
 						.fill(profilePicPlusButtonColor)
-						.frame(width: 150, height: 150)
+						.frame(width: 25, height: 25)
 						.overlay(
 							Image(systemName: "plus")
 								.foregroundColor(universalBackgroundColor)
@@ -136,10 +136,12 @@ struct ProfileView: View {
 							.background(Color.red)
 							.cornerRadius(20)
 					}
+					.padding(.bottom, 20)
 
 					Spacer()
 				}
-				.padding()
+				.padding(.horizontal)
+				.padding(.bottom, 20)
 			}
 			.background(universalBackgroundColor)
 			.alert(item: $userAuth.activeAlert) { alertType in

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/AddFriendToTagView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/AddFriendToTagView.swift
@@ -132,7 +132,7 @@ extension AddFriendToTagView {
 				await viewModel.addSelectedFriendsToTag(
 					friendTagId: friendTagId)
 			}
-			closeCallback
+			closeCallback?()
 		}) {
 			HStack {
 				Text("done")


### PR DESCRIPTION
- Event loading completely fixed (no more edge cases with edited date times)
- Added functionality to send chat messages under an event, with new `CreateChatMessageDTO`
- Added usernames to event cards
- `weak self` in `UserAuthViewModel` to suppress warning
- "CREATED BY YOU" vertical text
- log-in happens directly
- only showing location if event location exists
- self owned events have "edit" button instead of participation toggle
- Update event after sending chat message