### PR TITLE
Improvements: Profile, Auth, Miscellaneous

### DIFF
--- a/Spawn-App-iOS-SwiftUI/Models/DTOs/User/UserCreateDTO.swift
+++ b/Spawn-App-iOS-SwiftUI/Models/DTOs/User/UserCreateDTO.swift
@@ -1,0 +1,14 @@
+//
+//  UserCreateDTO.swift
+//  Spawn-App-iOS-SwiftUI
+//
+//  Created by Daniel Agapov on 2025-03-16.
+//
+
+struct UserCreateDTO: Codable {
+	let username: String
+	let firstName: String
+	let lastName: String
+	let bio: String
+	let email: String
+}

--- a/Spawn-App-iOS-SwiftUI/Models/DTOs/User/UserUpdateDTO.swift
+++ b/Spawn-App-iOS-SwiftUI/Models/DTOs/User/UserUpdateDTO.swift
@@ -1,0 +1,15 @@
+//
+//  UserUpdateDTO.swift
+//  Spawn-App-iOS-SwiftUI
+//
+//  Created by Daniel Agapov on 2025-03-24.
+//
+
+import Foundation
+
+struct UserUpdateDTO: Codable {
+    let username: String
+    let firstName: String
+    let lastName: String
+    let bio: String
+} 

--- a/Spawn-App-iOS-SwiftUI/Services/API/IAPIService.swift
+++ b/Spawn-App-iOS-SwiftUI/Services/API/IAPIService.swift
@@ -21,5 +21,10 @@ protocol IAPIService {
 	func updateData<T: Encodable, U: Decodable>(
 		_ object: T, to url: URL, parameters: [String: String]?
 	) async throws -> U
+	/// generic function for patching (PATCHing) data, given a model of type T, and returning the updated object
+	func patchData<T: Encodable, U: Decodable>(
+		from url: URL,
+		with object: T
+	) async throws -> U
 	func deleteData(from url: URL) async throws
 }

--- a/Spawn-App-iOS-SwiftUI/Services/API/MockAPIService.swift
+++ b/Spawn-App-iOS-SwiftUI/Services/API/MockAPIService.swift
@@ -171,4 +171,18 @@ class MockAPIService: IAPIService {
 	func deleteData(from url: URL) async throws {
 		// do nothing
 	}
+
+	func patchData<T: Encodable, U: Decodable>(
+		from url: URL,
+		with object: T
+	) async throws -> U {
+		// Handle user profile updates
+		if url.absoluteString.contains("users/") {
+			if U.self == BaseUserDTO.self {
+				return BaseUserDTO.danielAgapov as! U
+			}
+		}
+
+		throw APIError.invalidData
+	}
 }

--- a/Spawn-App-iOS-SwiftUI/ViewModels/AddFriendToTagViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/AddFriendToTagViewModel.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 class AddFriendToTagViewModel: ObservableObject {
-	@Published var friends: [UserDTO] =
-		MockAPIService.isMocking ? UserDTO.mockUsers : []
-	@Published var selectedFriends: [UserDTO] = []
+	@Published var friends: [BaseUserDTO] =
+	MockAPIService.isMocking ? [BaseUserDTO.danielLee, BaseUserDTO.danielAgapov] : []
+	@Published var selectedFriends: [BaseUserDTO] = []
 
 	var userId: UUID
 	var apiService: IAPIService
@@ -20,15 +20,17 @@ class AddFriendToTagViewModel: ObservableObject {
 		self.apiService = apiService
 	}
 
-	internal func fetchFriendsToAddToTag(friendTagId: UUID) async {
+	func fetchFriendsToAddToTag(friendTagId: UUID) async {
 		// full path: /api/v1/friendTags/friendsNotAddedToTag/{friendTagId}
 		if let url = URL(
 			string: APIService.baseURL
 				+ "friendTags/friendsNotAddedToTag/\(friendTagId)")
 		{
 			do {
-				let fetchedFriends: [UserDTO] = try await self.apiService
+				let fetchedFriends: [BaseUserDTO] = try await self.apiService
 					.fetchData(from: url, parameters: nil)
+
+				print(fetchedFriends)
 
 				// Ensure updating on the main thread
 				await MainActor.run {
@@ -43,7 +45,7 @@ class AddFriendToTagViewModel: ObservableObject {
 	}
 
 	// Toggle friend selection
-	func toggleFriendSelection(_ friend: UserDTO) {
+	func toggleFriendSelection(_ friend: BaseUserDTO) {
 		if selectedFriends.contains(where: { $0.id == friend.id }) {
 			selectedFriends.removeAll { $0.id == friend.id }  // Deselect
 		} else {

--- a/Spawn-App-iOS-SwiftUI/ViewModels/Event/EventDescriptionViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/Event/EventDescriptionViewModel.swift
@@ -91,9 +91,9 @@ class EventDescriptionViewModel: ObservableObject {
 		}
 	}
 
-	// Add a new method to fetch updated event data
+	// this method gets called after a chat message is sent, to update the
+	// chat messages in the event popup view, to include this chat message
 	private func fetchUpdatedEventData() async {
-		// Construct URL for fetching the updated event
 		if let url = URL(string: APIService.baseURL + "events/\(event.id)") {
 			do {
 				let updatedEvent: FullFeedEventDTO = try await self.apiService.fetchData(

--- a/Spawn-App-iOS-SwiftUI/ViewModels/UserAuthViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/UserAuthViewModel.swift
@@ -50,6 +50,9 @@ class UserAuthViewModel: NSObject, ObservableObject {
 	// Auth alerts for authentication-related errors
 	@Published var authAlert: AuthAlertType?
 
+	@Published var defaultPfpFetchError: Bool = false
+	@Published var defaultPfpUrlString: String? = nil
+
 	private init(apiService: IAPIService) {
 		self.apiService = apiService
 
@@ -119,6 +122,9 @@ class UserAuthViewModel: NSObject, ObservableObject {
 		self.shouldNavigateToUserInfoInputView = false
 		self.activeAlert = nil
 		self.authAlert = nil
+
+		self.defaultPfpFetchError = false
+		self.defaultPfpUrlString = nil
 	}
 
 	func check() {
@@ -325,6 +331,26 @@ class UserAuthViewModel: NSObject, ObservableObject {
 			}
 			await MainActor.run {
 				self.hasCheckedSpawnUserExistence = true
+			}
+		}
+	}
+
+	func spawnFetchDefaultProfilePic() async {
+		if let url = URL(string: APIService.baseURL + "users/default-pfp") {
+			do {
+				let fetchedDefaultPfpUrlString: String = try await self.apiService
+					.fetchData(
+						from: url,
+						parameters: nil
+					)
+
+				await MainActor.run {
+					self.defaultPfpUrlString = fetchedDefaultPfpUrlString
+				}
+			} catch {
+				await MainActor.run {
+					self.defaultPfpFetchError = true
+				}
 			}
 		}
 	}

--- a/Spawn-App-iOS-SwiftUI/ViewModels/UserAuthViewModel.swift
+++ b/Spawn-App-iOS-SwiftUI/ViewModels/UserAuthViewModel.swift
@@ -472,11 +472,3 @@ extension UserAuthViewModel: ASAuthorizationControllerDelegate {
 	}
 
 }
-
-struct UserCreateDTO: Codable {
-	let username: String
-	let firstName: String
-	let lastName: String
-	let bio: String
-	let email: String
-}

--- a/Spawn-App-iOS-SwiftUI/Views/Authentication/ImagePicker.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/Authentication/ImagePicker.swift
@@ -1,0 +1,256 @@
+//
+//  ImagePicker.swift
+//  Spawn-App-iOS-SwiftUI
+//
+//  Created by Daniel Agapov on 2025-03-16.
+//
+
+import SwiftUI
+import PhotosUI
+import UIKit
+
+struct ImagePicker: UIViewControllerRepresentable {
+	@Binding var selectedImage: UIImage?
+	@Environment(\.presentationMode) private var presentationMode
+
+	func makeUIViewController(context: Context) -> PHPickerViewController {
+		var config = PHPickerConfiguration()
+		config.filter = .images
+		let picker = PHPickerViewController(configuration: config)
+		picker.delegate = context.coordinator
+		return picker
+	}
+
+	func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {}
+
+	func makeCoordinator() -> Coordinator {
+		Coordinator(self)
+	}
+
+	class Coordinator: NSObject, PHPickerViewControllerDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+		let parent: ImagePicker
+
+		init(_ parent: ImagePicker) {
+			self.parent = parent
+		}
+
+		func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+			picker.dismiss(animated: true)
+
+			guard let provider = results.first?.itemProvider else { return }
+
+			if provider.canLoadObject(ofClass: UIImage.self) {
+				provider.loadObject(ofClass: UIImage.self) { [weak self] image, _ in
+					DispatchQueue.main.async {
+						if let image = image as? UIImage {
+							self?.showImageCropper(with: image)
+						}
+					}
+				}
+			}
+		}
+
+		func showImageCropper(with image: UIImage) {
+			let cropViewController = CropImageViewController(image: image) { [weak self] croppedImage in
+				DispatchQueue.main.async {
+					self?.parent.selectedImage = croppedImage
+				}
+			}
+
+			// Find the current view controller to present from
+			if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+			   let rootVC = windowScene.windows.first?.rootViewController {
+				var currentVC = rootVC
+				while let presentedVC = currentVC.presentedViewController {
+					currentVC = presentedVC
+				}
+				currentVC.present(cropViewController, animated: true)
+			}
+		}
+	}
+}
+
+class CropImageViewController: UIViewController {
+	private let imageView = UIImageView()
+	private let originalImage: UIImage
+	private let completion: (UIImage) -> Void
+
+	private let cropOverlayView = UIView()
+	private let cropFrameView = UIView()
+
+	init(image: UIImage, completion: @escaping (UIImage) -> Void) {
+		self.originalImage = image
+		self.completion = completion
+		super.init(nibName: nil, bundle: nil)
+	}
+
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		setupUI()
+	}
+
+	private func setupUI() {
+		view.backgroundColor = .black
+
+		// Setup image view
+		imageView.contentMode = .scaleAspectFit
+		imageView.image = originalImage
+		imageView.frame = view.bounds
+		view.addSubview(imageView)
+
+		// Setup crop overlay
+		cropOverlayView.frame = view.bounds
+		cropOverlayView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+		view.addSubview(cropOverlayView)
+
+		// Create circular crop frame
+		let minDimension = min(view.bounds.width, view.bounds.height) * 0.8
+		let cropSize = CGSize(width: minDimension, height: minDimension)
+		cropFrameView.frame = CGRect(
+			x: (view.bounds.width - cropSize.width) / 2,
+			y: (view.bounds.height - cropSize.height) / 2,
+			width: cropSize.width,
+			height: cropSize.height
+		)
+		cropFrameView.layer.cornerRadius = minDimension / 2
+		cropFrameView.layer.borderColor = UIColor.white.cgColor
+		cropFrameView.layer.borderWidth = 2
+		view.addSubview(cropFrameView)
+
+		// Cut the circular hole in the overlay
+		let path = UIBezierPath(rect: cropOverlayView.bounds)
+		let circlePath = UIBezierPath(ovalIn: cropFrameView.frame)
+		path.append(circlePath)
+		path.usesEvenOddFillRule = true
+
+		let maskLayer = CAShapeLayer()
+		maskLayer.path = path.cgPath
+		maskLayer.fillRule = .evenOdd
+		cropOverlayView.layer.mask = maskLayer
+
+		// Add buttons
+		let buttonStack = UIStackView()
+		buttonStack.axis = .horizontal
+		buttonStack.distribution = .fillEqually
+		buttonStack.spacing = 20
+
+		let cancelButton = UIButton(type: .system)
+		cancelButton.setTitle("Cancel", for: .normal)
+		cancelButton.setTitleColor(.white, for: .normal)
+		cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+
+		let doneButton = UIButton(type: .system)
+		doneButton.setTitle("Done", for: .normal)
+		doneButton.setTitleColor(.white, for: .normal)
+		doneButton.addTarget(self, action: #selector(doneTapped), for: .touchUpInside)
+
+		buttonStack.addArrangedSubview(cancelButton)
+		buttonStack.addArrangedSubview(doneButton)
+
+		view.addSubview(buttonStack)
+		buttonStack.translatesAutoresizingMaskIntoConstraints = false
+		NSLayoutConstraint.activate([
+			buttonStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
+			buttonStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
+			buttonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40),
+			buttonStack.heightAnchor.constraint(equalToConstant: 50)
+		])
+	}
+
+	@objc private func cancelTapped() {
+		dismiss(animated: true)
+	}
+
+	@objc private func doneTapped() {
+		let scaledCropFrame = convertCropFrameToImageCoordinates()
+		if let croppedImage = cropImage(with: scaledCropFrame) {
+			completion(croppedImage)
+		}
+		dismiss(animated: true)
+	}
+
+	private func convertCropFrameToImageCoordinates() -> CGRect {
+		// Convert the crop frame view's frame to the image view's coordinate space
+		let cropFrameInImageView = view.convert(cropFrameView.frame, to: imageView)
+
+		// Get the image's displayed frame within the image view
+		let imageViewSize = imageView.frame.size
+		let imageSize = originalImage.size
+
+		let imageAspect = imageSize.width / imageSize.height
+		let viewAspect = imageViewSize.width / imageViewSize.height
+
+		var imageDisplayRect = CGRect.zero
+
+		if imageAspect > viewAspect {
+			// Image is wider than view
+			let height = imageViewSize.width / imageAspect
+			let yOffset = (imageViewSize.height - height) / 2
+			imageDisplayRect = CGRect(x: 0, y: yOffset, width: imageViewSize.width, height: height)
+		} else {
+			// Image is taller than view
+			let width = imageViewSize.height * imageAspect
+			let xOffset = (imageViewSize.width - width) / 2
+			imageDisplayRect = CGRect(x: xOffset, y: 0, width: width, height: imageViewSize.height)
+		}
+
+		// Convert crop frame from image view coordinates to image coordinates
+		let scaleX = imageSize.width / imageDisplayRect.width
+		let scaleY = imageSize.height / imageDisplayRect.height
+
+		let imageX = (cropFrameInImageView.origin.x - imageDisplayRect.origin.x) * scaleX
+		let imageY = (cropFrameInImageView.origin.y - imageDisplayRect.origin.y) * scaleY
+		let imageWidth = cropFrameInImageView.width * scaleX
+		let imageHeight = cropFrameInImageView.height * scaleY
+
+		return CGRect(x: imageX, y: imageY, width: imageWidth, height: imageHeight)
+	}
+
+	private func cropImage(with rect: CGRect) -> UIImage? {
+		let imageSize = originalImage.size
+		let scale = originalImage.scale
+
+		// Ensure the cropping rect is within image bounds
+		let safeCropRect = CGRect(
+			x: max(0, rect.origin.x),
+			y: max(0, rect.origin.y),
+			width: min(rect.width, imageSize.width - rect.origin.x),
+			height: min(rect.height, imageSize.height - rect.origin.y)
+		)
+
+		// Scale crop rect to handle image scale
+		let scaledCropRect = CGRect(
+			x: safeCropRect.origin.x * scale,
+			y: safeCropRect.origin.y * scale,
+			width: safeCropRect.width * scale,
+			height: safeCropRect.height * scale
+		)
+
+		// Perform the crop
+		guard let cgImage = originalImage.cgImage?.cropping(to: scaledCropRect) else {
+			return nil
+		}
+
+		// Create a circular image
+		let ciImage = CIImage(cgImage: cgImage)
+		let filter = CIFilter(name: "CIRadialGradientMask")
+
+		let size = CGSize(width: cgImage.width, height: cgImage.height)
+		let smallerSide = min(size.width, size.height)
+		let radius = smallerSide / 2
+
+		filter?.setValue(ciImage, forKey: kCIInputImageKey)
+		filter?.setValue(CIVector(x: radius, y: radius), forKey: "inputCenter")
+		filter?.setValue(radius, forKey: "inputRadius0")
+		filter?.setValue(0, forKey: "inputRadius1")
+
+		// Create a circular image
+		let outputImage = UIImage(cgImage: cgImage, scale: scale, orientation: originalImage.imageOrientation)
+
+		return outputImage
+	}
+}

--- a/Spawn-App-iOS-SwiftUI/Views/Authentication/UserInfoInputView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/Authentication/UserInfoInputView.swift
@@ -45,8 +45,8 @@ struct UserInfoInputView: View {
 								.progressViewStyle(CircularProgressViewStyle(tint: .white))
 						)
 				}
-			} else {
-				AsyncImage(url: URL(string: userAuth.defaultPfpUrlString)) { image in
+			} else if let defaultPfpUrl = userAuth.defaultPfpUrlString {
+				AsyncImage(url: URL(string: defaultPfpUrl)) { image in
 					image
 						.ProfileImageModifier(imageType: .profilePage)
 				} placeholder: {
@@ -61,6 +61,17 @@ struct UserInfoInputView: View {
 								.foregroundColor(.white.opacity(0.7))
 						)
 				}
+			} else {
+				Circle()
+					.fill(.gray)
+					.frame(width: 150, height: 150)
+					.overlay(
+						Image(systemName: "person.fill")
+							.resizable()
+							.scaledToFit()
+							.frame(width: 60, height: 60)
+							.foregroundColor(.white.opacity(0.7))
+					)
 			}
 		}
 	}
@@ -195,33 +206,29 @@ struct UserInfoInputView: View {
 								if isFormValid {
 									isSubmitting = true
 									Task {
-										do {
-											// If no image is selected but we have a profile picture URL from Google/Apple,
-											// we'll pass nil for profilePicture and let the backend use the URL
-											print("Profile picture URL from provider: \(userAuth.profilePicUrl ?? "none")")
+										// If no image is selected but we have a profile picture URL from Google/Apple,
+										// we'll pass nil for profilePicture and let the backend use the URL
+										print("Profile picture URL from provider: \(userAuth.profilePicUrl ?? "none")")
 
-											await userAuth.spawnMakeUser(
-												username: username,
-												profilePicture: selectedImage, // Pass the selected image or nil
-												firstName: userAuth.givenName ?? "",
-												lastName: userAuth.familyName ?? "",
-												email: userAuth.authProvider == .apple ? email : userAuth.email ?? ""
-											)
+										await userAuth.spawnMakeUser(
+											username: username,
+											profilePicture: selectedImage, // Pass the selected image or nil
+											firstName: userAuth.givenName ?? "",
+											lastName: userAuth.familyName ?? "",
+											email: userAuth.authProvider == .apple ? email : userAuth.email ?? ""
+										)
 
-											// Show notification permission request after account creation
-											if userAuth.spawnUser != nil {
-												requestNotificationPermission()
-												// Only set navigation flag here after successful account creation
-												userAuth.isFormValid = true
-												userAuth.setShouldNavigateToFeedView()
-											} else {
-												errorMessage = "Failed to create user. Please try again."
-												showErrorAlert = true
-											}
-										} catch {
-											errorMessage = "Error: \(error.localizedDescription)"
+										// Show notification permission request after account creation
+										if userAuth.spawnUser != nil {
+											requestNotificationPermission()
+											// Only set navigation flag here after successful account creation
+											userAuth.isFormValid = true
+											userAuth.setShouldNavigateToFeedView()
+										} else {
+											errorMessage = "Failed to create user. Please try again."
 											showErrorAlert = true
 										}
+
 										isSubmitting = false
 									}
 								}

--- a/Spawn-App-iOS-SwiftUI/Views/Authentication/UserInfoInputView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/Authentication/UserInfoInputView.swift
@@ -3,26 +3,6 @@ import PhotosUI
 import UIKit
 import UserNotifications
 
-// Define constants if they're missing from your codebase
-let authPageBackgroundColor = Color(red: 0.1, green: 0.1, blue: 0.15) // Dark blue-black color
-let universalRectangleCornerRadius: CGFloat = 10
-
-// Extension for profile image modifiers if missing
-extension Image {
-	func ProfileImageModifier(imageType: ProfileImageType) -> some View {
-		self.resizable()
-			.scaledToFill()
-			.frame(width: imageType == .profilePage ? 150 : 40,
-				   height: imageType == .profilePage ? 150 : 40)
-			.clipShape(Circle())
-	}
-}
-
-enum ProfileImageType {
-	case profilePage
-	case navigationBar
-}
-
 struct UserInfoInputView: View {
 	@StateObject var userAuth = UserAuthViewModel.shared
 
@@ -66,16 +46,21 @@ struct UserInfoInputView: View {
 						)
 				}
 			} else {
-				Circle()
-					.fill(.gray)
-					.frame(width: 150, height: 150)
-					.overlay(
-						Image(systemName: "person.fill")
-							.resizable()
-							.scaledToFit()
-							.frame(width: 60, height: 60)
-							.foregroundColor(.white.opacity(0.7))
-					)
+				AsyncImage(url: URL(string: userAuth.defaultPfpUrlString)) { image in
+					image
+						.ProfileImageModifier(imageType: .profilePage)
+				} placeholder: {
+					Circle()
+						.fill(.gray)
+						.frame(width: 150, height: 150)
+						.overlay(
+							Image(systemName: "person.fill")
+								.resizable()
+								.scaledToFit()
+								.frame(width: 60, height: 60)
+								.foregroundColor(.white.opacity(0.7))
+						)
+				}
 			}
 		}
 	}

--- a/Spawn-App-iOS-SwiftUI/Views/Enums/DeleteAccountAlertType.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/Enums/DeleteAccountAlertType.swift
@@ -1,5 +1,5 @@
 //
-//  DeleteAccountAlertType.swift
+//  AlertTypes.swift
 //  Spawn-App-iOS-SwiftUI
 //
 //  Created by Daniel Agapov on 2025-02-19.
@@ -17,6 +17,42 @@ enum DeleteAccountAlertType: Identifiable {
 			case .deleteConfirmation: return 0
 			case .deleteSuccess: return 1
 			case .deleteError: return 2
+		}
+	}
+}
+
+enum AuthAlertType: Identifiable {
+	case providerMismatch
+	case emailAlreadyInUse
+	case createError
+	
+	var id: Int {
+		switch self {
+			case .providerMismatch: return 0
+			case .emailAlreadyInUse: return 1
+			case .createError: return 2
+		}
+	}
+	
+	var title: String {
+		switch self {
+			case .providerMismatch: 
+				return "Authentication Error"
+			case .emailAlreadyInUse: 
+				return "Email Already in Use"
+			case .createError: 
+				return "Account Creation Error"
+		}
+	}
+	
+	var message: String {
+		switch self {
+			case .providerMismatch: 
+				return "This account was created using a different sign-in method. Please try the other sign-in option."
+			case .emailAlreadyInUse: 
+				return "This email is already associated with an existing account. Please use a different email or sign in with the account this email is attached to."
+			case .createError: 
+				return "There was an error creating your account. Please try again later."
 		}
 	}
 }

--- a/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/EventDescriptionView.swift
@@ -28,92 +28,88 @@ struct EventDescriptionView: View {
 
 	var body: some View {
 		ScrollView {
-			ZStack {
-				// Main content
-				VStack(alignment: .leading, spacing: 20) {
-					// Title and Time Information
-					EventCardTopRowView(event: viewModel.event)
-					
-					// Username display
-					HStack {
-						usernamesView
-						Spacer()
-					}
-
-					VStack {
-						HStack {
-							// Note
-							if let note = viewModel.event.note {
-								Text("\(note)")
-									.font(.body)
-									.padding(.bottom, 15)
-									.foregroundColor(.white)
-									.font(.body)
-									.italic()
-							}
-						}
-						.frame(maxWidth: .infinity, alignment: .leading)
-
-						HStack(spacing: 10) {
-							EventInfoView(
-								event: viewModel.event, eventInfoType: .time)
-							
-							// Only show location if it exists
-							if viewModel.event.location?.name != nil && !(viewModel.event.location?.name.isEmpty ?? true) {
-								EventInfoView(
-									event: viewModel.event, eventInfoType: .location)
-							}
-							
-							Spacer()
-							
-							// Add participation toggle or edit button
-							Circle()
-								.CircularButton(
-									systemName: viewModel.event.isSelfOwned == true 
-										? "pencil" // Edit icon for self-owned events
-										: (viewModel.isParticipating ? "checkmark" : "star.fill"),
-									buttonActionCallback: {
-										Task {
-											if viewModel.event.isSelfOwned == true {
-												// Handle edit action
-												print("Edit event")
-												// TODO: Implement edit functionality
-											} else {
-												// Toggle participation for non-owned events
-												await viewModel.toggleParticipation()
-											}
-										}
-									})
-						}
-						.foregroundColor(.white)
-					}
-					.frame(maxWidth: .infinity)  // Ensures the HStack uses the full width of its parent
-
-					if let chatMessages = viewModel.event.chatMessages {
-						Divider()
-							.frame(height: 0.5)
-							.background(Color.black)
-							.opacity(1)
-						HStack {
-							Spacer()
-							Text(
-								"\(chatMessages.count) \(chatMessages.count == 1 ? "reply" : "replies")"
-							)
-							.foregroundColor(.black)
-							.opacity(0.7)
-							.font(.caption)
-						}
-						.frame(maxWidth: .infinity)
-					}
-
-					chatMessagesView
+			VStack(alignment: .leading, spacing: 20) {
+				// Title and Time Information
+				EventCardTopRowView(event: viewModel.event)
+				
+				// Username display
+				HStack {
+					usernamesView
+					Spacer()
 				}
-				.padding(20)
-				.background(color)
-				.cornerRadius(universalRectangleCornerRadius)
+
+				VStack {
+					HStack {
+						// Note
+						if let note = viewModel.event.note {
+							Text("\(note)")
+								.font(.body)
+								.padding(.bottom, 15)
+								.foregroundColor(.white)
+								.font(.body)
+								.italic()
+						}
+					}
+					.frame(maxWidth: .infinity, alignment: .leading)
+
+					HStack(spacing: 10) {
+						EventInfoView(
+							event: viewModel.event, eventInfoType: .time)
+						
+						// Only show location if it exists
+						if viewModel.event.location?.name != nil && !(viewModel.event.location?.name.isEmpty ?? true) {
+							EventInfoView(
+								event: viewModel.event, eventInfoType: .location)
+						}
+						
+						Spacer()
+						
+						// Add participation toggle or edit button
+						Circle()
+							.CircularButton(
+								systemName: viewModel.event.isSelfOwned == true 
+									? "pencil" // Edit icon for self-owned events
+									: (viewModel.isParticipating ? "checkmark" : "star.fill"),
+								buttonActionCallback: {
+									Task {
+										if viewModel.event.isSelfOwned == true {
+											// Handle edit action
+											print("Edit event")
+											// TODO: Implement edit functionality
+										} else {
+											// Toggle participation for non-owned events
+											await viewModel.toggleParticipation()
+										}
+									}
+								})
+					}
+					.foregroundColor(.white)
+				}
+				.frame(maxWidth: .infinity)  // Ensures the HStack uses the full width of its parent
+
+				if let chatMessages = viewModel.event.chatMessages {
+					Divider()
+						.frame(height: 0.5)
+						.background(Color.black)
+						.opacity(1)
+					HStack {
+						Spacer()
+						Text(
+							"\(chatMessages.count) \(chatMessages.count == 1 ? "reply" : "replies")"
+						)
+						.foregroundColor(.black)
+						.opacity(0.7)
+						.font(.caption)
+					}
+					.frame(maxWidth: .infinity)
+				}
+
+				chatMessagesView
 			}
+			.padding(20)
+			.background(color)
+			.cornerRadius(universalRectangleCornerRadius)
 		}
-		.scrollDisabled(true)  // to get fitting from `ScrollView`, without the actual scrolling, since that's only need for the `chatMessagesView`
 	}
 	
 	var usernamesView: some View {
@@ -133,8 +129,8 @@ struct EventDescriptionView: View {
 
 extension EventDescriptionView {
 	var chatMessagesView: some View {
-        VStack{
-            ScrollView(.vertical){
+        VStack(spacing: 10) {
+            ScrollView(.vertical) {
                 LazyVStack(spacing: 15) {
                     if let chatMessages = viewModel.event.chatMessages {
                         ForEach(chatMessages) { chatMessage in
@@ -142,13 +138,12 @@ extension EventDescriptionView {
                         }
                     }
                 }
+                .padding(.horizontal, 5)
             }
             .frame(maxHeight: 150)
 
 			chatBar
-				.padding(.horizontal, 25)
-				.padding(.vertical)
-		}
+        }
 		.padding(.top, 10)
 		.padding(.bottom, 10)
 		.background(Color.black.opacity(0.05))
@@ -248,12 +243,14 @@ extension EventDescriptionView {
 			}) {
 				Image(systemName: "paperplane.fill")
 					.foregroundColor(Color.black)
-					.padding(.trailing, 10)
 			}
+			.padding(.horizontal, 10)
 			.disabled(messageText.isEmpty) // Disable button when text is empty
 		}
+		.padding(8)
 		.background(Color.white)
 		.cornerRadius(universalRectangleCornerRadius)
+		.padding(.horizontal, 15)
 	}
 }
 

--- a/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FeedView.swift
@@ -60,6 +60,23 @@ struct FeedView: View {
 					isActive: showingEventDescriptionPopup
 						|| showingEventCreationPopup
 				)
+				.gesture(DragGesture(minimumDistance: 3.0, coordinateSpace: .local)
+					.onEnded { value in
+						switch(value.translation.width, value.translation.height) {
+							case (...0, -30...30): // left swipe
+								if let currentIndex = viewModel.tags.firstIndex(where: { $0.id == viewModel.activeTag?.id }),
+								   currentIndex < viewModel.tags.count - 1 {
+									viewModel.activeTag = viewModel.tags[currentIndex + 1]
+								}
+							case (0..., -30...30): // right swipe
+								if let currentIndex = viewModel.tags.firstIndex(where: { $0.id == viewModel.activeTag?.id }),
+								   currentIndex > 0 {
+									viewModel.activeTag = viewModel.tags[currentIndex - 1]
+								}
+							default: break
+						}
+					}
+				)
 			}
 			.background(universalBackgroundColor)
 			.onAppear {

--- a/Spawn-App-iOS-SwiftUI/Views/FriendsView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/FriendsView.swift
@@ -54,6 +54,21 @@ struct FriendsView: View {
 				.navigationBarHidden(true)
 				.dimmedBackground(
 					isActive: showAddFriendToTagButtonPressedPopupView)
+				.gesture(DragGesture(minimumDistance: 3.0, coordinateSpace: .local)
+					.onEnded { value in
+						switch(value.translation.width, value.translation.height) {
+							case (...0, -30...30): // left swipe
+								if selectedTab == .friends {
+									selectedTab = .tags
+								}
+							case (0..., -30...30): // right swipe
+								if selectedTab == .tags {
+									selectedTab = .friends
+								}
+							default: break
+						}
+					}
+				)
 			}
 			if showAddFriendToTagButtonPressedPopupView {
 				addFriendToTagButtonPopupView

--- a/Spawn-App-iOS-SwiftUI/Views/ProfileView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/ProfileView.swift
@@ -64,8 +64,8 @@ struct ProfileView: View {
 								.ProfileImageModifier(imageType: .profilePage)
 						}
 
-						// Only show the plus button for current user's profile
-						if isCurrentUserProfile {
+						// Only show the plus button for current user's profile when in edit mode
+						if isCurrentUserProfile && editingState == .save {
 							Circle()
 								.fill(profilePicPlusButtonColor)
 								.frame(width: 25, height: 25)
@@ -163,19 +163,19 @@ struct ProfileView: View {
 								editingState = .save
 							case .save:
 								Task {
-									// Update profile picture if selected
-									if let newImage = selectedImage {
-										await userAuth.updateProfilePicture(newImage)
-										selectedImage = nil
-									}
-									
-									// Update profile info
+									// Update profile info first
 									await userAuth.spawnEditProfile(
 										username: username,
 										firstName: firstName,
 										lastName: lastName,
 										bio: bio
 									)
+									
+									// Update profile picture if selected
+									if let newImage = selectedImage {
+										await userAuth.updateProfilePicture(newImage)
+										// Don't clear selectedImage so it keeps showing in the UI
+									}
 								}
 								editingState = .edit
 							}

--- a/Spawn-App-iOS-SwiftUI/Views/ProfileView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/ProfileView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 import PhotosUI
 
 struct ProfileView: View {
-	// TODO DANIEL: make a real API call here, using a new view model -> for editing bio and maybe other user details
 	let user: BaseUserDTO
 	@State private var bio: String
 	@State private var username: String

--- a/Spawn-App-iOS-SwiftUI/Views/ProfileView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/ProfileView.swift
@@ -45,6 +45,7 @@ struct ProfileView: View {
 								} placeholder: {
 									Circle()
 										.fill(Color.gray)
+										.frame(width: 150, height: 150)
 								}
 							}
 						} else {
@@ -61,7 +62,7 @@ struct ProfileView: View {
 									Image(systemName: "plus")
 										.foregroundColor(universalBackgroundColor)
 								)
-								.offset(x: 10, y: -10)
+								.offset(x: -10, y: -10)
 						}
 					}
 					.padding(.top, 20)
@@ -104,6 +105,9 @@ struct ProfileView: View {
 							case .edit:
 								editingState = .save
 							case .save:
+								Task {
+									await userAuth.spawnEditProfile()
+								}
 								editingState = .edit
 							}
 						}) {

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/EventCreationFriendsViews/InviteTagsView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/EventCreationFriendsViews/InviteTagsView.swift
@@ -140,9 +140,19 @@ extension InviteTagRow {
 
 struct InviteTagFriendsView: View {
 	var friends: [BaseUserDTO]?
+	
+	// Computed properties to use throughout the view
+	private var displayedFriends: [BaseUserDTO] {
+		return (friends ?? []).prefix(3).map { $0 }
+	}
+	
+	private var remainingCount: Int {
+		return (friends?.count ?? 0) - displayedFriends.count
+	}
+	
 	var body: some View {
-		ForEach(friends ?? []) { friend in
-			HStack(spacing: -10) {
+		HStack(spacing: -10) {
+			ForEach(displayedFriends) { friend in
 				if let pfpUrl = friend.profilePicture {
 					AsyncImage(url: URL(string: pfpUrl)) {
 						image in
@@ -158,7 +168,15 @@ struct InviteTagFriendsView: View {
 						.fill(Color.gray)
 						.frame(width: 25, height: 25)
 				}
-
+			}
+			
+			// Show "+X" indicator if there are more than 3 friends
+			if remainingCount > 0 {
+				Text("+\(remainingCount)")
+					.font(.system(size: 12, weight: .bold))
+					.foregroundColor(.white)
+					.frame(width: 25, height: 25)
+					.background(Circle().fill(universalAccentColor))
 			}
 		}
 	}

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/EventCreationFriendsViews/InviteView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/EventCreationFriendsViews/InviteView.swift
@@ -29,6 +29,21 @@ struct InviteView: View {
 			}
 			.frame(maxWidth: .infinity, maxHeight: .infinity)
 			.background(universalBackgroundColor)
+			.gesture(DragGesture(minimumDistance: 3.0, coordinateSpace: .local)
+				.onEnded { value in
+					switch(value.translation.width, value.translation.height) {
+						case (...0, -30...30): // left swipe
+							if selectedTab == .friends {
+								selectedTab = .tags
+							}
+						case (0..., -30...30): // right swipe
+							if selectedTab == .tags {
+								selectedTab = .friends
+							}
+						default: break
+					}
+				}
+			)
 		}
 	}
 }

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/AddFriendToTagView.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/AddFriendToTagView.swift
@@ -68,11 +68,11 @@ struct AddFriendToTagView: View {
 }
 
 struct FriendRowForAddingFriendsToTag: View {
-	var friend: UserDTO
+	var friend: BaseUserDTO
 	@State private var isClicked: Bool = false
 	@ObservedObject var viewModel: AddFriendToTagViewModel
 
-	init(friend: UserDTO, viewModel: AddFriendToTagViewModel) {
+	init(friend: BaseUserDTO, viewModel: AddFriendToTagViewModel) {
 		self.friend = friend
 		self.viewModel = viewModel
 	}

--- a/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/TagRow.swift
+++ b/Spawn-App-iOS-SwiftUI/Views/SubComponents/NewTagsSubViews/Tags/TagRow.swift
@@ -137,6 +137,19 @@ extension TagRow {
 struct TagFriendsView: View {
 	var friends: [BaseUserDTO]?
 	@Binding var isExpanded: Bool
+	
+	// Computed properties to use throughout the view
+	private var displayedFriends: [BaseUserDTO] {
+		return (friends ?? []).prefix(3).map { $0 }
+	}
+	
+	private var remainingCount: Int {
+		return (friends?.count ?? 0) - displayedFriends.count
+	}
+	
+	private var trailingPadding: CGFloat {
+		return min(CGFloat(displayedFriends.count) * 15, 45) + (remainingCount > 0 ? 30 : 0)
+	}
 
 	var body: some View {
 		ZStack {
@@ -150,12 +163,12 @@ struct TagFriendsView: View {
 					.foregroundColor(.white)
 					.clipShape(Circle())
 			}
-			.offset(x: CGFloat((friends?.count ?? 0)) * 15)  // Position the button after the last profile picture
+			.offset(x: min(CGFloat(displayedFriends.count) * 15, 45))  // Position the button after the last profile picture or max 3
 
+			// Show only up to 3 friends
 			ForEach(
-				Array((friends ?? []).enumerated().reversed()), id: \.element.id
-			) {
-				index, friend in
+				Array(displayedFriends.enumerated().reversed()), id: \.element.id
+			) { index, friend in
 				if let pfpUrl = friend.profilePicture {
 					AsyncImage(url: URL(string: pfpUrl)) { image in
 						image
@@ -173,9 +186,18 @@ struct TagFriendsView: View {
 						.offset(x: CGFloat(index) * 15)  // Adjust overlap spacing
 				}
 			}
-
+			
+			// Show "+X" indicator if there are more than 3 friends
+			if remainingCount > 0 {
+				Text("+\(remainingCount)")
+					.font(.system(size: 12, weight: .bold))
+					.foregroundColor(.white)
+					.frame(width: 25, height: 25)
+					.background(Circle().fill(universalAccentColor))
+					.offset(x: 45)  // Position after the 3rd friend
+			}
 		}
-		.padding(.trailing, CGFloat((friends?.count ?? 0) * 15))
+		.padding(.trailing, trailingPadding)
 	}
 }
 


### PR DESCRIPTION
## `ProfileView.swift`
- Profile view has different buttons for if it's your own vs. someone else's 
- Edit profile functionality to address another part of #142 
- Upload pfp functionality to address another part of #142 #133 
- Upon clicking "Edit":
    - Image uploading to replace your pfp is enabled, and shows the "plus" button
    - The name expands to first & last name inputs

## Authentication
- Auth checking for 409 status codes, for previously-used emails when manually inputting for apple account creation
- Back button for `UserInfoInputView.swift`
- UI adjustments to `UserInfoInputView.swift`
- Getting default pfp to address part of #142 

## Miscellaneous
- Adjustments for `BaseUserDTO` in Views
- API Service `patchData()` method in interface + mock & real
- #131 
- Swiping between friends/tags views (for both browsing and inviting) now navigates between them in `InviteView` and `FriendsView`
    - Plus, this happens for feed event tag filtering in `FeedView`